### PR TITLE
Update README.rst to direct users to use https:// instead of insecure git://

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Install using pip:
 
     OR
 
-    pip install git+git://github.com/olucurious/PyFCM.git
+    pip install git+https://github.com/olucurious/PyFCM.git
 
 PyFCM supports Android and iOS.
 


### PR DESCRIPTION
The git protocol is insecure -- no server validation whatsoever is performed. Doing `pip install git+git://...` without an `@<commit_hash>` can compromise a user's machine if an attacker is able to intercept their connection (trivial on unsecured or shared-password WiFi, for example).

This change directs users to do the safer thing instead.