### PR TITLE
Bump version number to 0.0.10

### DIFF
--- a/pyfcm/__meta__.py
+++ b/pyfcm/__meta__.py
@@ -6,7 +6,7 @@ __title__ = 'pyfcm'
 __summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android & iOS)..'
 __url__ = 'https://github.com/olucurious/pyfcm'
 
-__version__ = '0.0.7'
+__version__ = '0.0.10'
 
 __install_requires__ = ['requests']
 


### PR DESCRIPTION
Currently the latest release tag has version number 0.0.9, but __meta__.py has version 0.0.7. This results in the confusing situation where a user does `pip install git+git://github.com/olucurious/PyFCM.git` and then `pip freeze` reports `pyfcm==0.0.7`.

While it's too late to fix `0.0.8` or `0.0.9`, it is possible to fix it for `0.0.10` onwards.
