### PR TITLE
support for extra_kwargs in notify_single_device/notify_multiple_devices functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,4 +68,8 @@ v1.0.0 (12-07-2016)
 
 .. _Emmanuel Olucurious: https://github.com/olucurious
 
+v1.0.0 (16-07-2016)
+-------------------
+- Added extra_kwargs for dinamic vars in notify_single_device/notify_multiple_devices functions
 
+.. _Sergey Afonin: https://github.com/safonin

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -111,7 +111,8 @@ class BaseAPI(object):
                       body_loc_key=None,
                       body_loc_args=None,
                       title_loc_key=None,
-                      title_loc_args=None):
+                      title_loc_args=None,
+                      **extra_kwargs):
 
         """
 
@@ -179,6 +180,9 @@ class BaseAPI(object):
         else:
             # This is needed for iOS when we are sending only custom data messages
             fcm_payload['content_available'] = True
+
+        if extra_kwargs:
+            fcm_payload.update(extra_kwargs)
 
         return self.json_dumps(fcm_payload)
 


### PR DESCRIPTION
Add support for extra_kwargs in notify_single_device/notify_multiple_devices functions
It may be necessary for cases where the payload is constructed dynamically and no possibility to define each function parameter