### PR TITLE
Remove extraneous assignment of 1 to success

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -65,8 +65,6 @@ class BaseAPI(object):
         canonical_ids = parsed_response.get('canonical_ids', 0)
         results = parsed_response.get('results', [])
         message_id = parsed_response.get('message_id', None)  # for topic messages
-        if message_id:
-            success = 1
 
         return {'multicast_id': multicast_id,
                 'success': success,


### PR DESCRIPTION
success is not a boolean: as a result, the removed lines could produce an incorrect result (success = 1) in the case that multiple messages were sent. Regardless, success was already set accurately on line 63. See here for more info: https://developers.google.com/cloud-messaging/http-server-ref