### PR TITLE
None response hotfix

### DIFF
--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -82,7 +82,7 @@ class FCMNotification(BaseAPI):
                                      title_loc_args=title_loc_args)
 
         self.send_request([payload])
-        self.parse_responses()
+        return self.parse_responses()
 
     def notify_multiple_devices(self,
                                 registration_ids=None,


### PR DESCRIPTION
Issue #77 

A quick look revealed that only a return statement was missing in function notify_single_device. 
I think you can release version 1.1.1 with this fix.

I will try to write some unit tests as soon as possible.