### PR TITLE
- Updated response retrieval, notify_single_device response returns s…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,3 +95,12 @@ v1.1.5 (16-11-2016)
 - Fix some message components not being sent if message_body is None (click_action, badge, sound, etc)
 
 .. _João Ricardo Lourenço: https://github.com/Jorl17
+
+v1.2.0 (16-11-2016)
+-------------------
+
+- Updated response retrieval, notify_single_device response returns single dict while notify_multiple_devices returns a list of dicts
+- You can now pass extra argument by passing it as key value in a dictionary as extra_kwargs to any notification sending method you want to use
+- It is now possible to send a notification without setting body or content available
+
+.. _Emmanuel Olucurious: https://github.com/olucurious

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,11 @@ Links
 - Project: https://github.com/olucurious/pyfcm
 - PyPi: https://pypi.python.org/pypi/pyfcm/
 
+Updates
+-------
+
+- MAJOR API UPDATES (DECEMBER 2016): https://github.com/olucurious/PyFCM/blob/master/README.rst
+
 
 Quickstart
 ==========
@@ -105,6 +110,13 @@ Send a data message.
     # To a single device
     result = push_service.notify_single_device(registration_id=registration_id, data_message=data_message)
 
+    # To send extra kwargs (keyword arguments not provided in any of the methods),
+    # pass it as a key value in a dictionary to the method being used
+    extra_kwargs = {
+        'content_available': True
+    }
+    result = push_service.notify_single_device(registration_id=registration_id, data_message=data_message, extra_kwargs=extra_kwargs)
+
     # Use notification messages when you want FCM to handle displaying a notification on your app's behalf.
     # Use data messages when you just want to process the messages only in your app.
     # PyFCM can send a message including both notification and data payloads.
@@ -168,8 +180,11 @@ Access response data.
     response['canonical_ids'] #Number of results that contain a canonical registration token.
     response['results'] #Array of objects representing the status of the messages processed.
 
-    result = [{response dict},...] #if notify_multiple_devices is used
-    result = {response dict} #if notify_single_device is used
+    # For notify_multiple_devices
+    result = [{response dict},...] #list of response dicts is returned
+
+    # For notify_single_device or notify_topic_subscribers
+    result = {response dict} #single response dict is returned
 
     # The response objects are listed in the same order as the request (i.e., for each registration ID in the request,
     # its response is listed in the same index in the response).

--- a/pyfcm/__meta__.py
+++ b/pyfcm/__meta__.py
@@ -6,7 +6,7 @@ __title__ = 'pyfcm'
 __summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android & iOS)..'
 __url__ = 'https://github.com/olucurious/pyfcm'
 
-__version__ = '1.1.5'
+__version__ = '1.2.0'
 
 __install_requires__ = ['requests']
 

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -86,6 +86,7 @@ class BaseAPI(object):
                       body_loc_args=None,
                       title_loc_key=None,
                       title_loc_args=None,
+                      content_available=None,
                       **extra_kwargs):
 
         """
@@ -140,15 +141,16 @@ class BaseAPI(object):
             fcm_payload['notification'] = {'icon': message_icon}
             if body_loc_key:
                 fcm_payload['notification']['body_loc_key'] = body_loc_key
-            else:
-                # This is needed for iOS when we are sending only custom data messages
-                fcm_payload['content_available'] = True
             if body_loc_args:
                 fcm_payload['notification']['body_loc_args'] = body_loc_args
             if title_loc_key:
                 fcm_payload['notification']['title_loc_key'] = title_loc_key
             if title_loc_args:
                 fcm_payload['notification']['title_loc_args'] = title_loc_args
+
+        # This is needed for iOS when we are sending only custom data messages
+        if content_available and isinstance(content_available, bool):
+            fcm_payload['content_available'] = content_available
 
         if click_action:
             fcm_payload['notification']['click_action'] = click_action
@@ -169,7 +171,7 @@ class BaseAPI(object):
         return self.json_dumps(fcm_payload)
 
     def send_request(self, payloads=None):
-
+        self.send_request_responses = []
         for payload in payloads:
             response = requests.post(self.FCM_END_POINT, headers=self.request_headers(), data=payload)
             if self.FCM_REQ_PROXIES:

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -23,7 +23,9 @@ class FCMNotification(BaseAPI):
                              body_loc_key=None,
                              body_loc_args=None,
                              title_loc_key=None,
-                             title_loc_args=None):
+                             title_loc_args=None,
+                             content_available=None,
+                             extra_kwargs={}):
 
         """
         Send push notification to a single device
@@ -79,10 +81,12 @@ class FCMNotification(BaseAPI):
                                      body_loc_key=body_loc_key,
                                      body_loc_args=body_loc_args,
                                      title_loc_key=title_loc_key,
-                                     title_loc_args=title_loc_args)
+                                     title_loc_args=title_loc_args,
+                                     content_available=content_available,
+                                     **extra_kwargs)
 
         self.send_request([payload])
-        return self.parse_responses()[-1:]
+        return self.parse_responses()[-1:][0]
 
     def notify_multiple_devices(self,
                                 registration_ids=None,
@@ -105,7 +109,9 @@ class FCMNotification(BaseAPI):
                                 body_loc_key=None,
                                 body_loc_args=None,
                                 title_loc_key=None,
-                                title_loc_args=None):
+                                title_loc_args=None,
+                                content_available=None,
+                                extra_kwargs={}):
 
         """
         Sends push notification to multiple devices,
@@ -167,7 +173,9 @@ class FCMNotification(BaseAPI):
                                                    body_loc_key=body_loc_key,
                                                    body_loc_args=body_loc_args,
                                                    title_loc_key=title_loc_key,
-                                                   title_loc_args=title_loc_args))
+                                                   title_loc_args=title_loc_args,
+                                                   content_available=content_available,
+                                                   **extra_kwargs))
             self.send_request(payloads)
             return self.parse_responses()
         else:
@@ -188,7 +196,9 @@ class FCMNotification(BaseAPI):
                                          body_loc_key=body_loc_key,
                                          body_loc_args=body_loc_args,
                                          title_loc_key=title_loc_key,
-                                         title_loc_args=title_loc_args)
+                                         title_loc_args=title_loc_args,
+                                         content_available=content_available,
+                                         **extra_kwargs)
             self.send_request([payload])
             return self.parse_responses()
 
@@ -213,7 +223,9 @@ class FCMNotification(BaseAPI):
                                  body_loc_key=None,
                                  body_loc_args=None,
                                  title_loc_key=None,
-                                 title_loc_args=None):
+                                 title_loc_args=None,
+                                 content_available=None,
+                                 extra_kwargs={}):
 
         """
         Sends push notification to multiple devices subscribe to a topic
@@ -271,6 +283,8 @@ class FCMNotification(BaseAPI):
                                      body_loc_key=body_loc_key,
                                      body_loc_args=body_loc_args,
                                      title_loc_key=title_loc_key,
-                                     title_loc_args=title_loc_args)
+                                     title_loc_args=title_loc_args,
+                                     content_available=content_available,
+                                     **extra_kwargs)
         self.send_request([payload])
-        return self.parse_responses()
+        return self.parse_responses()[-1:][0]

--- a/test.py
+++ b/test.py
@@ -2,9 +2,13 @@
 # -*- coding: utf-8 -*-
 __author__ = 'olucurious'
 from pyfcm import FCMNotification
-
-push_service = FCMNotification(api_key="<api-key>")
+from pprint import pprint
+push_service = FCMNotification(api_key="<server key>")
 registration_id="<device registration_id>"
 message = "Hope you're having fun this weekend, don't forget to check today's news"
+result = push_service.notify_single_device(registration_id='1')
+pprint(result)
+result = push_service.notify_multiple_devices(registration_ids=['1','2'])
+pprint(result)
 result = push_service.notify_topic_subscribers(topic_name="global", message_body=message)
-print(result)
+pprint(result)


### PR DESCRIPTION
…ingle dict while notify_multiple_devices returns a list of dicts

- You can now pass extra argument by passing it as key value in a dictionary as extra_kwargs to any notification sending method you want to use
- It is now possible to send a notification without setting body or content available