### PR TITLE
- Updated response retrieval, notify_single_device response returns s…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Links
 Updates
 -------
 
-- MAJOR API UPDATES (DECEMBER 2016): https://github.com/olucurious/PyFCM/blob/master/README.rst
+- MAJOR API UPDATES (DECEMBER 2016): https://github.com/olucurious/PyFCM/releases/tag/1.2.0
 
 
 Quickstart

--- a/pyfcm/__meta__.py
+++ b/pyfcm/__meta__.py
@@ -6,7 +6,7 @@ __title__ = 'pyfcm'
 __summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android & iOS)..'
 __url__ = 'https://github.com/olucurious/pyfcm'
 
-__version__ = '1.2.0'
+__version__ = '1.2.0.1'
 
 __install_requires__ = ['requests']
 


### PR DESCRIPTION
…ingle dict while notify_multiple_devices returns a list of dicts

- You can now pass extra argument by passing it as key value in a dictionary as extra_kwargs to any notification sending method you want to use
- It is now possible to send a notification without setting body or content available