### PR TITLE
Add missing README quote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Appengine users should define their environment
 
 .. code-block:: python
 
-    push_service = FCMNotification(api_key="<api-key>", proxy_dict=proxy_dict, env='app_engine)
+    push_service = FCMNotification(api_key="<api-key>", proxy_dict=proxy_dict, env='app_engine')
     result = push_service.notify_multiple_devices(registration_ids=registration_ids, message_body=message, low_priority=True)
 
 Sending a message to a topic.


### PR DESCRIPTION
I think app_engine is supposed to be a string in this context.