### PR TITLE
Add the abilty to send only a data message.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,9 +112,9 @@ Send a data message.
 
     # Sending a data message only payload, do NOT include message_body also do NOT include notification body
     # To multiple devices
-    result = push_service.message_multiple_devices(registration_ids=registration_ids, data_message=data_message)
+    result = push_service.multiple_devices_data_message(registration_ids=registration_ids, data_message=data_message)
     # To a single device
-    result = push_service.message_single_device(registration_id=registration_id, data_message=data_message)
+    result = push_service.single_device_data_message(registration_id=registration_id, data_message=data_message)
 
     # To send extra kwargs (keyword arguments not provided in any of the methods),
     # pass it as a key value in a dictionary to the method being used

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Send a data message.
     # With FCM, you can send two types of messages to clients:
     # 1. Notification messages, sometimes thought of as "display messages."
     # 2. Data messages, which are handled by the client app.
+    # 3. Notification messages with optional data payload.
 
     # Client app is responsible for processing data messages. Data messages have only custom key-value pairs. (Python dict)
     # Data messages let developers send up to 4KB of custom key-value pairs.
@@ -109,11 +110,11 @@ Send a data message.
     # To a single device
     result = push_service.notify_single_device(registration_id=registration_id, message_body=message_body, data_message=data_message)
 
-    # Sending a data message only payload, do NOT include message_body
+    # Sending a data message only payload, do NOT include message_body also do NOT include notification body
     # To multiple devices
-    result = push_service.notify_multiple_devices(registration_ids=registration_ids, data_message=data_message)
+    result = push_service.message_multiple_devices(registration_ids=registration_ids, data_message=data_message)
     # To a single device
-    result = push_service.notify_single_device(registration_id=registration_id, data_message=data_message)
+    result = push_service.message_single_device(registration_id=registration_id, data_message=data_message)
 
     # To send extra kwargs (keyword arguments not provided in any of the methods),
     # pass it as a key value in a dictionary to the method being used

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -94,6 +94,7 @@ class BaseAPI(object):
                       title_loc_key=None,
                       title_loc_args=None,
                       content_available=None,
+                      remove_notification=False,
                       **extra_kwargs):
 
         """
@@ -186,6 +187,10 @@ class BaseAPI(object):
 
         if extra_kwargs:
             fcm_payload['notification'].update(extra_kwargs)
+
+        # Do this if you only want to send a data message.
+        if remove_notification:
+            del fcm_payload['notification']
 
         return self.json_dumps(fcm_payload)
 

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -105,8 +105,7 @@ class FCMNotification(BaseAPI):
                              dry_run=False,
                              data_message=None,
                              content_available=None,
-                             timeout=5,
-                             extra_kwargs={}):
+                             timeout=5):
 
         """
         Send push message to a single device
@@ -264,8 +263,7 @@ class FCMNotification(BaseAPI):
                                 dry_run=False,
                                 data_message=None,
                                 content_available=None,
-                                timeout=5,
-                                extra_kwargs={}):
+                                timeout=5):
 
         """
         Sends push message to multiple devices,

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -94,6 +94,73 @@ class FCMNotification(BaseAPI):
         self.send_request([payload], timeout)
         return self.parse_responses()
 
+    def message_single_device(self,
+                             registration_id=None,
+                             condition=None,
+                             collapse_key=None,
+                             delay_while_idle=False,
+                             time_to_live=None,
+                             restricted_package_name=None,
+                             low_priority=False,
+                             dry_run=False,
+                             data_message=None,
+                             content_available=None,
+                             timeout=5,
+                             extra_kwargs={}):
+
+        """
+        Send push message to a single device
+
+        Args:
+            registration_id (str): FCM device registration IDs.
+            data_message (dict): Data message payload to send alone or with the notification message
+
+        Keyword Args:
+            collapse_key (str, optional): Identifier for a group of messages
+                that can be collapsed so that only the last message gets sent
+                when delivery can be resumed. Defaults to ``None``.
+            delay_while_idle (bool, optional): If ``True`` indicates that the
+                message should not be sent until the device becomes active.
+            time_to_live (int, optional): How long (in seconds) the message
+                should be kept in FCM storage if the device is offline. The
+                maximum time to live supported is 4 weeks. Defaults to ``None``
+                which uses the FCM default of 4 weeks.
+            low_priority (boolean, optional): Whether to send notification with
+                the low priority flag. Defaults to ``False``.
+            restricted_package_name (str, optional): Package name of the
+                application where the registration IDs must match in order to
+                receive the message. Defaults to ``None``.
+            dry_run (bool, optional): If ``True`` no message will be sent but
+                request will be tested.
+            timeout (int, optional): set time limit for the request
+        Returns:
+            :dict:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
+            Response from FCM server.
+
+        Raises:
+            AuthenticationError: If :attr:`api_key` is not set or provided or there is an error authenticating the sender.
+            FCMServerError: Internal server error or timeout error on Firebase cloud messaging server
+            InvalidDataError: Invalid data provided
+            InternalPackageError: Mostly from changes in the response of FCM, contact the project owner to resolve the issue
+        """
+        if registration_id is None:
+            raise InvalidDataError('Invalid registration ID')
+        # [registration_id] cos we're sending to a single device
+        payload = self.parse_payload(registration_ids=[registration_id],
+                                     condition=condition,
+                                     collapse_key=collapse_key,
+                                     delay_while_idle=delay_while_idle,
+                                     time_to_live=time_to_live,
+                                     restricted_package_name=restricted_package_name,
+                                     low_priority=low_priority,
+                                     dry_run=dry_run,
+                                     data_message=data_message,
+                                     content_available=content_available,
+                                     remove_notification=True)
+
+        self.send_request([payload], timeout)
+        return self.parse_responses()
+
     def notify_multiple_devices(self,
                                 registration_ids=None,
                                 message_body=None,
@@ -183,6 +250,73 @@ class FCMNotification(BaseAPI):
                                                title_loc_args=title_loc_args,
                                                content_available=content_available,
                                                **extra_kwargs))
+        self.send_request(payloads, timeout)
+        return self.parse_responses()
+
+    def message_multiple_devices(self,
+                                registration_ids=None,
+                                condition=None,
+                                collapse_key=None,
+                                delay_while_idle=False,
+                                time_to_live=None,
+                                restricted_package_name=None,
+                                low_priority=False,
+                                dry_run=False,
+                                data_message=None,
+                                content_available=None,
+                                timeout=5,
+                                extra_kwargs={}):
+
+        """
+        Sends push message to multiple devices,
+        can send to over 1000 devices
+
+        Args:
+            registration_ids (list): FCM device registration IDs.
+            data_message (dict): Data message payload to send alone or with the notification message
+
+        Keyword Args:
+            collapse_key (str, optional): Identifier for a group of messages
+                that can be collapsed so that only the last message gets sent
+                when delivery can be resumed. Defaults to ``None``.
+            delay_while_idle (bool, optional): If ``True`` indicates that the
+                message should not be sent until the device becomes active.
+            time_to_live (int, optional): How long (in seconds) the message
+                should be kept in FCM storage if the device is offline. The
+                maximum time to live supported is 4 weeks. Defaults to ``None``
+                which uses the FCM default of 4 weeks.
+            low_priority (boolean, optional): Whether to send notification with
+                the low priority flag. Defaults to ``False``.
+            restricted_package_name (str, optional): Package name of the
+                application where the registration IDs must match in order to
+                receive the message. Defaults to ``None``.
+            dry_run (bool, optional): If ``True`` no message will be sent but
+                request will be tested.
+        Returns:
+            :tuple:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
+            Response from FCM server.
+
+        Raises:
+            AuthenticationError: If :attr:`api_key` is not set or provided or there is an error authenticating the sender.
+            FCMServerError: Internal server error or timeout error on Firebase cloud messaging server
+            InvalidDataError: Invalid data provided
+            InternalPackageError: JSON parsing error, mostly from changes in the response of FCM, create a new github issue to resolve it.
+        """
+        payloads = list()
+        registration_id_chunks = self.registration_id_chunks(registration_ids)
+        for registration_ids in registration_id_chunks:
+            # appends a payload with a chunk of registration ids here
+            payloads.append(self.parse_payload(registration_ids=registration_ids,
+                                               condition=condition,
+                                               collapse_key=collapse_key,
+                                               delay_while_idle=delay_while_idle,
+                                               time_to_live=time_to_live,
+                                               restricted_package_name=restricted_package_name,
+                                               low_priority=low_priority,
+                                               dry_run=dry_run,
+                                               data_message=data_message,
+                                               content_available=content_available,
+                                               remove_notification=True))
         self.send_request(payloads, timeout)
         return self.parse_responses()
 

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -94,18 +94,18 @@ class FCMNotification(BaseAPI):
         self.send_request([payload], timeout)
         return self.parse_responses()
 
-    def message_single_device(self,
-                             registration_id=None,
-                             condition=None,
-                             collapse_key=None,
-                             delay_while_idle=False,
-                             time_to_live=None,
-                             restricted_package_name=None,
-                             low_priority=False,
-                             dry_run=False,
-                             data_message=None,
-                             content_available=None,
-                             timeout=5):
+    def single_device_data_message(self,
+                                   registration_id=None,
+                                   condition=None,
+                                   collapse_key=None,
+                                   delay_while_idle=False,
+                                   time_to_live=None,
+                                   restricted_package_name=None,
+                                   low_priority=False,
+                                   dry_run=False,
+                                   data_message=None,
+                                   content_available=None,
+                                   timeout=5):
 
         """
         Send push message to a single device
@@ -252,18 +252,18 @@ class FCMNotification(BaseAPI):
         self.send_request(payloads, timeout)
         return self.parse_responses()
 
-    def message_multiple_devices(self,
-                                registration_ids=None,
-                                condition=None,
-                                collapse_key=None,
-                                delay_while_idle=False,
-                                time_to_live=None,
-                                restricted_package_name=None,
-                                low_priority=False,
-                                dry_run=False,
-                                data_message=None,
-                                content_available=None,
-                                timeout=5):
+    def multiple_devices_data_message(self,
+                                      registration_ids=None,
+                                      condition=None,
+                                      collapse_key=None,
+                                      delay_while_idle=False,
+                                      time_to_live=None,
+                                      restricted_package_name=None,
+                                      low_priority=False,
+                                      dry_run=False,
+                                      data_message=None,
+                                      content_available=None,
+                                      timeout=5):
 
         """
         Sends push message to multiple devices,


### PR DESCRIPTION
Currently we're sending the notification object regardless.  This sends a notification rather than a data message as described here: [https://firebase.google.com/docs/cloud-messaging/concept-options
](https://firebase.google.com/docs/cloud-messaging/concept-options
)

I've added a remove_notification flag which is set to True in the message_single_device/message_multiple_devices functions, which I also created.  This just removes the notification object in the requests sent to FCM.  The new message functions are essentially just copies of the notify functions with the notification arguments removed and the remove_notification argument set to True.

I'm open to implementing this in a different way if needed.  I played with the idea of a basic parse_payload function that does the things required for notifications and messages and then adding in notification required fields.  