### PR TITLE
 Add optional json_encoder argument to BaseAPI constructor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,3 +119,10 @@ v1.2.9 (07-04-2017)
 - Fixed issue with notification extra kwargs
 
 .. _Emmanuel Olucurious: https://github.com/olucurious
+
+Unreleased
+-------------------
+
+- Add optional json_encoder argument to BaseAPI to allow configuring the JSONEncoder used for parse_payload
+
+.. _Carlos Arrastia: https://github.com/carrasti

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -28,7 +28,7 @@ class BaseAPI(object):
     #: wake a sleeping device and open a network connection to your server.
     FCM_HIGH_PRIORITY = 'high'
 
-    def __init__(self, api_key=None, proxy_dict=None, env=None):
+    def __init__(self, api_key=None, proxy_dict=None, env=None, json_encoder=None):
         """
 
         :type proxy_dict: dict, api_key: string
@@ -49,6 +49,7 @@ class BaseAPI(object):
                 appengine.monkeypatch()
             except:
                 pass
+        self.json_encoder = json_encoder
 
     def request_headers(self):
         return {
@@ -67,7 +68,7 @@ class BaseAPI(object):
 
     def json_dumps(self, data):
         """Standardized json.dumps function with separators and sorted keys set."""
-        return (json.dumps(data, separators=(',', ':'), sort_keys=True)
+        return (json.dumps(data, separators=(',', ':'), sort_keys=True, cls=self.json_encoder)
                 .encode('utf8'))
 
     def parse_payload(self,


### PR DESCRIPTION
This allows custom encoding of objects to JSON
https://docs.python.org/3/library/json.html#json.JSONEncoder

The encoder class is passed to `json.dumps` call throughthe `cls` argument

This allows configuring the JSONEncoder to be different by the default one and for example transform `datetime` values to its `isoformat`

I use this with the rest_framework encoder in my project like in this example:

```
from pyfcm import FCMNotification
from rest_framework.utils.encoders import JSONEncoder
from datetime import datetime

push_service = FCMNotification(api_key="<api-key>", json_encoder=JSONEncoder)
result = push_service.single_device_data_message(
    registration_id="<registration_id>", 
    data_message={'timestamp': datetime.now()})
```
