### PR TITLE
Fcm priority

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,3 +126,7 @@ Unreleased
 - Add optional json_encoder argument to BaseAPI to allow configuring the JSONEncoder used for parse_payload
 
 .. _Carlos Arrastia: https://github.com/carrasti
+
+- Addition of a android dictionary to set fcm priority
+
+.. _Pratik Sayare: https://github.com/gizmopratik

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -115,10 +115,13 @@ class BaseAPI(object):
             # Which is why it's in the `else` block since `condition` is used when multiple topics are being targeted
             if topic_name:
                 fcm_payload['to'] = '/topics/%s' % topic_name
+        # Add a object within the payload to set priority of the messages with reference to
+        # https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message
+        # required for legacy http otherwise data messages with priority as high are sent with normal priority
         if low_priority:
-            fcm_payload['priority'] = self.FCM_LOW_PRIORITY
+            fcm_payload['android'] = dict(priority=self.FCM_LOW_PRIORITY)
         else:
-            fcm_payload['priority'] = self.FCM_HIGH_PRIORITY
+            fcm_payload['android'] = dict(priority=self.FCM_HIGH_PRIORITY)
 
         if delay_while_idle:
             fcm_payload['delay_while_idle'] = delay_while_idle


### PR DESCRIPTION
with reference to https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message the payload sent with the dict ` 'android': {'priority': 'high'}` for data messages is working as expected than sending as `'priority': 'high'` in the payload, test devices used for this are Xiaomi and One Plus different models, using android the notification is delivered even when the app is idle whereas in the other case the notification is not delivered. Tested the issue with time_to_live=0 for highest latency and without android as the outer dict, was unable to get the message. Reproducible by using the above devices with battery optimization on for a certain application. I have forked your repo and using it in a production environment with android dict with success. If you have any queries please do reach out to me at gizmopratik@gmail.com. Thanks.