### PR TITLE
Remove extra 0xC2 bytes from README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,8 @@ Send a data message.
     # To send extra kwargs (keyword arguments not provided in any of the methods),
     # pass it as a key value in a dictionary to the method being used
     extra_kwargs = {
-        'priority': 'high'
-    }
+        'priority': 'high'
+    }
     result = push_service.notify_single_device(registration_id=registration_id, data_message=data_message, extra_kwargs=extra_kwargs)
 
     # To process background notifications in iOS 10, set content_available


### PR DESCRIPTION
These extra 0xC2s cause installation under Python 3 to fail with this error:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "setup.py", line 41, in <module>
        long_description=read('README.rst'),
      File "setup.py", line 17, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/usr/local/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 4184: ordinal not in range(128)