### PR TITLE
Add android_channel_id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,3 +130,7 @@ Unreleased
 - Addition of a android dictionary to set fcm priority
 
 .. _Pratik Sayare: https://github.com/gizmopratik
+
+- Add android_channel_id
+
+-- _Lucas Hild: https://github.com/Lanseuo

--- a/pyfcm/__meta__.py
+++ b/pyfcm/__meta__.py
@@ -2,7 +2,7 @@
 """Define project metadata
 """
 __title__ = 'pyfcm'
-__summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android & iOS)..'
+__summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android, iOS and Web)'
 __url__ = 'https://github.com/olucurious/pyfcm'
 
 __version__ = '1.4.5'

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -1,10 +1,15 @@
 import json
 import os
+import requests
 import time
 
-import requests
-
-from .errors import *
+from .errors import (
+    AuthenticationError,
+    FCMError,
+    FCMServerError,
+    InternalPackageError,
+    InvalidDataError
+)
 
 
 class BaseAPI(object):
@@ -30,15 +35,19 @@ class BaseAPI(object):
 
     def __init__(self, api_key=None, proxy_dict=None, env=None, json_encoder=None):
         """
-
-        :type proxy_dict: dict, api_key: string
+        Parameters:
+            api_key (str): Firebase API key
+            proxy_dict (dict): proxy used for requests with keys "http" and "https"
+            env (str)
+            json_encoder: custom json encoder
         """
         if api_key:
             self._FCM_API_KEY = api_key
         elif os.getenv('FCM_API_KEY', None):
             self._FCM_API_KEY = os.getenv('FCM_API_KEY', None)
         else:
-            raise AuthenticationError("Please provide the api_key in the google-services.json file")
+            raise AuthenticationError(
+                "Please provide the api_key as an argument or in the google-services.json file")
         self.FCM_REQ_PROXIES = None
         if proxy_dict and isinstance(proxy_dict, dict) and (('http' in proxy_dict) or ('https' in proxy_dict)):
             self.FCM_REQ_PROXIES = proxy_dict
@@ -52,6 +61,12 @@ class BaseAPI(object):
         self.json_encoder = json_encoder
 
     def request_headers(self):
+        """
+        Generates request headers
+
+        Returns:
+            dict: "Content-Type" and "Authorization"
+        """
         return {
             "Content-Type": self.CONTENT_TYPE,
             "Authorization": "key=" + self._FCM_API_KEY,
@@ -96,12 +111,12 @@ class BaseAPI(object):
                       title_loc_args=None,
                       content_available=None,
                       remove_notification=False,
+                      android_channel_id=None,
                       extra_notification_kwargs={},
                       **extra_kwargs):
-
         """
-
-        :rtype: json
+        Returns:
+            dict: fcm payload
         """
         fcm_payload = dict()
         if registration_ids:
@@ -133,7 +148,8 @@ class BaseAPI(object):
             if isinstance(time_to_live, int):
                 fcm_payload['time_to_live'] = time_to_live
             else:
-                raise InvalidDataError("Provided time_to_live is not an integer")
+                raise InvalidDataError(
+                    "Provided time_to_live is not an integer")
         if restricted_package_name:
             fcm_payload['restricted_package_name'] = restricted_package_name
         if dry_run:
@@ -143,7 +159,8 @@ class BaseAPI(object):
             if isinstance(data_message, dict):
                 fcm_payload['data'] = data_message
             else:
-                raise InvalidDataError("Provided data_message is in the wrong format")
+                raise InvalidDataError(
+                    "Provided data_message is in the wrong format")
 
         fcm_payload['notification'] = {}
         if message_icon:
@@ -172,6 +189,9 @@ class BaseAPI(object):
                     fcm_payload['notification']['title_loc_args'] = title_loc_args
                 else:
                     raise InvalidDataError('title_loc_args should be an array')
+
+        if android_channel_id:
+            fcm_payload['notification']['android_channel_id'] = android_channel_id
 
         # This is needed for iOS when we are sending only custom data messages
         if content_available and isinstance(content_available, bool):
@@ -204,10 +224,17 @@ class BaseAPI(object):
 
     def do_request(self, payload, timeout):
         if self.FCM_REQ_PROXIES:
-            response = requests.post(self.FCM_END_POINT, headers=self.request_headers(), data=payload,
-                                     proxies=self.FCM_REQ_PROXIES, timeout=timeout)
+            response = requests.post(
+                self.FCM_END_POINT,
+                headers=self.request_headers(),
+                data=payload,
+                proxies=self.FCM_REQ_PROXIES, timeout=timeout)
         else:
-            response = requests.post(self.FCM_END_POINT, headers=self.request_headers(), data=payload, timeout=timeout)
+            response = requests.post(
+                self.FCM_END_POINT,
+                headers=self.request_headers(),
+                data=payload,
+                timeout=timeout)
         if 'Retry-After' in response.headers and int(response.headers['Retry-After']) > 0:
             sleep_time = int(response.headers['Retry-After'])
             time.sleep(sleep_time)
@@ -221,17 +248,17 @@ class BaseAPI(object):
             self.send_request_responses.append(response)
 
     def registration_info_request(self, registration_id):
-        """ Makes a request for registration info and returns the response
-            object
         """
-        response = requests.get('https://iid.googleapis.com/iid/info/' + registration_id,
-                               headers=self.request_headers(),
-                               params={'details': 'true'})
+        Makes a request for registration info and returns the response object
+        """
+        response = requests.get(
+            'https://iid.googleapis.com/iid/info/' + registration_id,
+            headers=self.request_headers(),
+            params={'details': 'true'})
         return response
 
     def clean_registration_ids(self, registration_ids=[]):
-        """ Return list of active IDS from the list of registration_ids
-        """
+        """Return list of active IDS from the list of registration_ids"""
         valid_registration_ids = []
         for registration_id in registration_ids:
             details = self.registration_info_request(registration_id)
@@ -240,8 +267,8 @@ class BaseAPI(object):
         return valid_registration_ids
 
     def get_registration_id_info(self, registration_id):
-        """ Returns details related to a registration id if it exists
-            otherwise return None
+        """
+        Returns details related to a registration id if it exists otherwise return None
         """
         details = self.registration_info_request(registration_id)
         if details.status_code == 200:
@@ -249,28 +276,32 @@ class BaseAPI(object):
         return None
 
     def subscribe_registration_ids_to_topic(self, registration_ids, topic_name):
-        """ Subscribes a list of registration ids to a topic
-        """
-        url = '''https://iid.googleapis.com/iid/v1:batchAdd'''
+        """Subscribes a list of registration ids to a topic"""
+        url = "https://iid.googleapis.com/iid/v1:batchAdd"
         payload = json.dumps({
-            'to': '/topics/'+topic_name,
+            'to': '/topics/' + topic_name,
             'registration_tokens': registration_ids,
         })
         response = requests.post(
-           url,
-           headers=self.request_headers(),
-           data=payload,
+            url,
+            headers=self.request_headers(),
+            data=payload,
         )
         if response.status_code == 200:
             return True
         elif response.status_code == 400:
-            error = json.loads( response.content )
+            error = json.loads(response.content)
             raise InvalidDataError(error['error'])
         else:
             raise FCMError()
 
     def unsubscribe_registration_ids_from_topic(self, registration_ids, topic_name):
-        """ Unsubscribes a list of registration ids from a topic
+        """
+        Unsubscribes a list of registration ids from a topic
+
+        Arguments:
+            registration_ids (list): devices that will be unsubscribed
+            topic_name (str): name of topic
         """
         url = '''https://iid.googleapis.com/iid/v1:batchRemove'''
         payload = json.dumps({
@@ -278,21 +309,24 @@ class BaseAPI(object):
             'registration_tokens': registration_ids,
         })
         response = requests.post(
-           url, 
-           headers=self.request_headers(),
-           data=payload,
+            url,
+            headers=self.request_headers(),
+            data=payload,
         )
         if response.status_code == 200:
             return True
         elif response.status_code == 400:
-            error = json.loads( response.content )
+            error = json.loads(response.content)
             raise InvalidDataError(error['error'])
         else:
             raise FCMError()
-        
+
     def parse_responses(self):
         """
-        Returns a python dict of multicast_ids(list), success(int), failure(int), canonical_ids(int), results(list) and optional topic_message_id(str but None by default)
+        Parses responses from FCM API
+
+        Returns:
+            dict: multicast_ids(list), success(int), failure(int), canonical_ids(int), results(list) and optional topic_message_id(str but None by default)
         """
         response_dict = {
             'multicast_ids': list(),
@@ -310,7 +344,8 @@ class BaseAPI(object):
                 server and tries to get out the important return variables
                 """
                 if 'content-length' in response.headers and int(response.headers['content-length']) <= 0:
-                    raise FCMServerError("FCM server connection error, the response is empty")
+                    raise FCMServerError(
+                        "FCM server connection error, the response is empty")
                 else:
                     parsed_response = response.json()
 
@@ -319,7 +354,8 @@ class BaseAPI(object):
                     failure = parsed_response.get('failure', 0)
                     canonical_ids = parsed_response.get('canonical_ids', 0)
                     results = parsed_response.get('results', [])
-                    message_id = parsed_response.get('message_id', None)  # for topic messages
+                    message_id = parsed_response.get(
+                        'message_id', None)  # for topic messages
                     if message_id:
                         success = 1
                     if multicast_id:
@@ -330,7 +366,8 @@ class BaseAPI(object):
                     response_dict['results'].extend(results)
                     response_dict['topic_message_id'] = message_id
             elif response.status_code == 401:
-                raise AuthenticationError("There was an error authenticating the sender account")
+                raise AuthenticationError(
+                    "There was an error authenticating the sender account")
             elif response.status_code == 400:
                 raise InternalPackageError(response.text)
             else:

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -26,10 +26,10 @@ class FCMNotification(BaseAPI):
                              title_loc_key=None,
                              title_loc_args=None,
                              content_available=None,
+                             android_channel_id=None,
                              timeout=5,
                              extra_notification_kwargs=None,
                              extra_kwargs={}):
-
         """
         Send push notification to a single device
 
@@ -56,7 +56,9 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
+            android_channel_id (str): new in Android O
             timeout (int, optional): set time limit for the request
+
         Returns:
             :dict:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -89,6 +91,7 @@ class FCMNotification(BaseAPI):
                                      body_loc_args=body_loc_args,
                                      title_loc_key=title_loc_key,
                                      title_loc_args=title_loc_args,
+                                     android_channel_id=android_channel_id,
                                      content_available=content_available,
                                      extra_notification_kwargs=extra_notification_kwargs,
                                      **extra_kwargs)
@@ -107,10 +110,10 @@ class FCMNotification(BaseAPI):
                                    dry_run=False,
                                    data_message=None,
                                    content_available=None,
+                                   android_channel_id=None,
                                    timeout=5,
                                    extra_notification_kwargs=None,
                                    extra_kwargs={}):
-
         """
         Send push message to a single device
 
@@ -135,7 +138,9 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
+            android_channel_id (str): new in Android O
             timeout (int, optional): set time limit for the request
+
         Returns:
             :dict:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -160,6 +165,7 @@ class FCMNotification(BaseAPI):
                                      data_message=data_message,
                                      content_available=content_available,
                                      remove_notification=True,
+                                     android_channel_id=android_channel_id,
                                      extra_notification_kwargs=extra_notification_kwargs,
                                      **extra_kwargs)
 
@@ -189,10 +195,10 @@ class FCMNotification(BaseAPI):
                                 title_loc_key=None,
                                 title_loc_args=None,
                                 content_available=None,
+                                android_channel_id=None,
                                 timeout=5,
                                 extra_notification_kwargs=None,
                                 extra_kwargs={}):
-
         """
         Sends push notification to multiple devices,
         can send to over 1000 devices
@@ -220,6 +226,8 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
+            android_channel_id (str): new in Android O
+
         Returns:
             :tuple:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -255,6 +263,7 @@ class FCMNotification(BaseAPI):
                                                title_loc_key=title_loc_key,
                                                title_loc_args=title_loc_args,
                                                content_available=content_available,
+                                               android_channel_id=android_channel_id,
                                                extra_notification_kwargs=extra_notification_kwargs,
                                                **extra_kwargs))
         self.send_request(payloads, timeout)
@@ -274,7 +283,6 @@ class FCMNotification(BaseAPI):
                                       timeout=5,
                                       extra_notification_kwargs=None,
                                       extra_kwargs={}):
-
         """
         Sends push message to multiple devices,
         can send to over 1000 devices
@@ -300,6 +308,7 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
+
         Returns:
             :tuple:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -353,10 +362,10 @@ class FCMNotification(BaseAPI):
                                  title_loc_key=None,
                                  title_loc_args=None,
                                  content_available=None,
+                                 android_channel_id=None,
                                  timeout=5,
                                  extra_notification_kwargs=None,
                                  extra_kwargs={}):
-
         """
         Sends push notification to multiple devices subscribed to a topic
 
@@ -385,6 +394,8 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
+            android_channel_id (str): new in Android O
+
         Returns:
             :tuple:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -417,6 +428,7 @@ class FCMNotification(BaseAPI):
                                      title_loc_key=title_loc_key,
                                      title_loc_args=title_loc_args,
                                      content_available=content_available,
+                                     android_channel_id=android_channel_id,
                                      extra_notification_kwargs=extra_notification_kwargs,
                                      **extra_kwargs)
         self.send_request([payload], timeout)


### PR DESCRIPTION
Starting in Android 8.0 (API level 26), all notifications must be assigned to a channel or it will not appear.

I added the parameter 'android_channel_id' to methods that send a push notification.

[Android Developer Reference](https://developer.android.com/guide/topics/ui/notifiers/notifications#ManageChannels)