### PR TITLE
pass ensure_ascii=False to json.dumps to reduce payload size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,3 +134,7 @@ Unreleased
 - Add android_channel_id
 
 -- _Lucas Hild: https://github.com/Lanseuo
+
+- Force to not ensure ascii when dumping payload to json
+
+-- _Roman Tolkachyov: https://gihub.com/romantolkachyov

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -71,8 +71,13 @@ class BaseAPI(object):
 
     def json_dumps(self, data):
         """Standardized json.dumps function with separators and sorted keys set."""
-        return (json.dumps(data, separators=(',', ':'), sort_keys=True, cls=self.json_encoder)
-                .encode('utf8'))
+        return json.dumps(
+            data, 
+            separators=(',', ':'), 
+            sort_keys=True, 
+            cls=self.json_encoder, 
+            ensure_ascii=False
+        ).encode('utf8')
 
     def parse_payload(self,
                       registration_ids=None,


### PR DESCRIPTION
Tested with FCM:
1) unicode allowed
2) payload size measured right