### PR TITLE
 Add configurable retries to info endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,3 +134,7 @@ Unreleased
 - Add android_channel_id
 
 -- _Lucas Hild: https://github.com/Lanseuo
+
+- Add configurable retries to info endpoint
+
+-- _Christy O'Reilly: https://github.com/c-oreills

--- a/pyfcm/__meta__.py
+++ b/pyfcm/__meta__.py
@@ -5,7 +5,7 @@ __title__ = 'pyfcm'
 __summary__ = 'Python client for FCM - Firebase Cloud Messaging (Android, iOS and Web)'
 __url__ = 'https://github.com/olucurious/pyfcm'
 
-__version__ = '1.4.5'
+__version__ = '1.4.6'
 
 __install_requires__ = ['requests', 'requests-toolbelt']
 


### PR DESCRIPTION
We've started getting a lot of `ConnectionErrors` which break the loop of `clean_registration_ids`. This adds configurable retries to alleviate this.