### PR TITLE
Fix time_to_live check so that 0 is valid.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,3 +138,7 @@ Unreleased
 - Add configurable retries to info endpoint
 
 .. _Christy O'Reilly: https://github.com/c-oreills
+
+- Fix time_to_live check to allow 0
+
+.. _Stephen Kwong: https://github.com/skwong2

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -222,7 +222,7 @@ class BaseAPI(object):
             fcm_payload['delay_while_idle'] = delay_while_idle
         if collapse_key:
             fcm_payload['collapse_key'] = collapse_key
-        if time_to_live:
+        if time_to_live is not None:
             if isinstance(time_to_live, int):
                 fcm_payload['time_to_live'] = time_to_live
             else:

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -58,7 +58,7 @@ def test_parse_payload(base_api):
         sound="Test",
         collapse_key="Test",
         delay_while_idle=False,
-        time_to_live=100,
+        time_to_live=0,
         restricted_package_name="Test",
         low_priority=False,
         dry_run=False,
@@ -90,6 +90,9 @@ def test_parse_payload(base_api):
         "tag": "Test",
         "title": "Test"
     }
+
+    assert 'time_to_live' in data
+    assert data['time_to_live'] == 0
 
 
 def test_clean_registration_ids(base_api):


### PR DESCRIPTION
According to the firebase documentation 0 is a valid value for `time_to_live`. This fixes the check so that we can send that value along.

> Another advantage of specifying the lifespan of a message is that FCM never throttles messages with a time-to-live value of 0 seconds. In other words, FCM guarantees best effort for messages that must be delivered "now or never." Keep in mind that a time_to_live value of 0 means messages that can't be delivered immediately are discarded. However, because such messages are never stored, this provides the best latency for sending notification messages.