### PR TITLE
[#261] make work PyFCM asynchronously

### DIFF
--- a/pyfcm/async_fcm.py
+++ b/pyfcm/async_fcm.py
@@ -1,0 +1,34 @@
+import asyncio
+import aiohttp
+import json
+
+async def fetch_tasks(end_point:str,headers:dict,payloads:list,timeout:int):
+    """
+
+    :param end_point (str) : FCM endpoint
+    :param headers (dict) : FCM Request Headers
+    :param payloads (list) : payloads contains bytes after self.parse_payload
+    :param timeout (int) : FCM timeout
+    :return:
+    """
+    fetches = [asyncio.Task(send_request(end_point=end_point,headers=headers,payload=payload,timeout=timeout)) for payload in payloads]
+    return await asyncio.gather(*fetches)
+
+
+async def send_request(end_point,headers,payload,timeout=5):
+    """
+
+    :param end_point (str) : FCM endpoint
+    :param headers (dict) : FCM Request Headers
+    :param payloads (list) : payloads contains bytes after self.parse_payload
+    :param timeout (int) : FCM timeout
+    :return:
+    """
+    timeout = aiohttp.ClientTimeout(total=timeout)
+
+    async with aiohttp.ClientSession(headers=headers,timeout=timeout) as session:
+
+        async with session.post(end_point,data=payload) as res:
+            result = await res.text()
+            result = json.loads(result)
+            return result

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -473,3 +473,15 @@ class BaseAPI(object):
             else:
                 raise FCMServerError("FCM server is temporarily unavailable")
         return response_dict
+
+    def send_async_request(self,params_list,timeout):
+
+        import asyncio
+        from .async_fcm import fetch_tasks
+
+        payloads = [ self.parse_payload(**params) for params in params_list ]
+        responses = asyncio.new_event_loop().run_until_complete(fetch_tasks(end_point=self.FCM_END_POINT,headers=self.request_headers(),payloads=payloads,timeout=timeout))
+
+        return responses
+
+

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -51,7 +51,7 @@ class BaseAPI(object):
 
         self.FCM_REQ_PROXIES = None
         self.requests_session = requests.Session()
-        retries = Retry(backoff_factor=1, status_forcelist=[502, 503, 504],
+        retries = Retry(backoff_factor=1, status_forcelist=[502, 503],
                         method_whitelist=(Retry.DEFAULT_METHOD_WHITELIST | frozenset(['POST'])))
         self.requests_session.mount('http://', adapter or HTTPAdapter(max_retries=retries))
         self.requests_session.mount('https://', adapter or HTTPAdapter(max_retries=retries))

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -494,7 +494,7 @@ class FCMNotification(BaseAPI):
         )
         self.send_request([payload], timeout)
         return self.parse_responses()
-    
+
     def topic_subscribers_data_message(self,
                                        topic_name=None,
                                        condition=None,
@@ -508,7 +508,7 @@ class FCMNotification(BaseAPI):
                                        content_available=None,
                                        timeout=5,
                                        extra_notification_kwargs=None,
-                                       extra_kwargs={}):                                 
+                                       extra_kwargs={}):
         """
         Sends data notification to multiple devices subscribed to a topic
         Args:
@@ -516,7 +516,7 @@ class FCMNotification(BaseAPI):
             condition (condition): Topic condition to deliver messages to
             A topic name is a string that can be formed with any character in [a-zA-Z0-9-_.~%]
             data_message (dict): Data message payload to send alone or with the notification message
-            
+
         Keyword Args:
             collapse_key (str, optional): Identifier for a group of messages
                 that can be collapsed so that only the last message gets sent
@@ -534,7 +534,7 @@ class FCMNotification(BaseAPI):
                 receive the message. Defaults to ``None``.
             dry_run (bool, optional): If ``True`` no message will be sent but
                 request will be tested.
-            
+
         Returns:
             :tuple:`multicast_id(long), success(int), failure(int), canonical_ids(int), results(list)`:
             Response from FCM server.
@@ -561,3 +561,17 @@ class FCMNotification(BaseAPI):
                                      **extra_kwargs)
         self.send_request([payload], timeout)
         return self.parse_responses()
+
+    def async_notify_multiple_devices(self,params_list:list=[],timeout=5):
+        """
+                Sends push notification to multiple devices with personalized templates
+
+                Args:
+                    params_list (list): list of parameters ( the sames as notify_multiple_devices)
+                    timeout (int, optional): set time limit for the request
+
+        """
+
+        payloads = [ self.parse_payload(params) for params in params_list ]
+
+        return self.send_async_request(payloads=payloads,timeout=timeout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.6.0
+aiohttp>=3.6.2

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -146,3 +146,32 @@ def test_notify_with_args(push_service):
         extra_notification_kwargs={},
         extra_kwargs={}
     )
+def test_async_notify(push_service):
+    params = {"registration_ids" : ['Test'],
+    "message_body" : "Test",
+    "message_title" : "Test",
+    "message_icon" : "Test",
+    "sound" : "Test",
+    "collapse_key" : "Test",
+    "delay_while_idle" : False,
+    "time_to_live" : 100,
+    "restricted_package_name" : "Test",
+    "low_priority" : False,
+    "dry_run" : True,
+    "data_message" : {"test": "test"},
+    "click_action" : "Test",
+    "badge" : "Test",
+    "color" : "Test",
+    "tag" : "Test",
+    "body_loc_key" : "Test",
+    "body_loc_args" : "Test",
+    "title_loc_key" : "Test",
+    "title_loc_args" : "Test",
+    "content_available" : "Test",
+    "android_channel_id" : "Test"
+    }
+
+    params_list = [params for _ in range(100)]
+
+    push_service.send_async_request(params_list,timeout=5)
+


### PR DESCRIPTION
For purpose : try to pyfcm asynchronously and send personalized messages
The parameters are the same as notify_multiple_devices except **the parameters are list which contains multiple parameters**
You can send the messages in personalized format