### PR TITLE
Replace deprecated urllib3.Retry options

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,3 +142,7 @@ Unreleased
 - Fix time_to_live check to allow 0
 
 .. _Stephen Kwong: https://github.com/skwong2
+
+- Replace deprecated urllib3.Retry options
+
+.. _Frederico Jordan: https://github.com/fredericojordan

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -52,7 +52,7 @@ class BaseAPI(object):
         self.FCM_REQ_PROXIES = None
         self.requests_session = requests.Session()
         retries = Retry(backoff_factor=1, status_forcelist=[502, 503],
-                        method_whitelist=(Retry.DEFAULT_METHOD_WHITELIST | frozenset(['POST'])))
+                        allowed_methods=(Retry.DEFAULT_ALLOWED_METHODS | frozenset(['POST'])))
         self.requests_session.mount('http://', adapter or HTTPAdapter(max_retries=retries))
         self.requests_session.mount('https://', adapter or HTTPAdapter(max_retries=retries))
         self.requests_session.headers.update(self.request_headers())

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -27,7 +27,7 @@ class FCMNotification(BaseAPI):
                              title_loc_args=None,
                              content_available=None,
                              android_channel_id=None,
-                             timeout=5,
+                             timeout=120,
                              extra_notification_kwargs=None,
                              extra_kwargs={}):
         """
@@ -128,7 +128,7 @@ class FCMNotification(BaseAPI):
                                    data_message=None,
                                    content_available=None,
                                    android_channel_id=None,
-                                   timeout=5,
+                                   timeout=120,
                                    extra_notification_kwargs=None,
                                    extra_kwargs={}):
         """
@@ -218,7 +218,7 @@ class FCMNotification(BaseAPI):
                                 title_loc_args=None,
                                 content_available=None,
                                 android_channel_id=None,
-                                timeout=5,
+                                timeout=120,
                                 extra_notification_kwargs=None,
                                 extra_kwargs={}):
         """
@@ -323,7 +323,7 @@ class FCMNotification(BaseAPI):
                                       dry_run=False,
                                       data_message=None,
                                       content_available=None,
-                                      timeout=5,
+                                      timeout=120,
                                       extra_notification_kwargs=None,
                                       extra_kwargs={}):
         """
@@ -410,7 +410,7 @@ class FCMNotification(BaseAPI):
                                  title_loc_args=None,
                                  content_available=None,
                                  android_channel_id=None,
-                                 timeout=5,
+                                 timeout=120,
                                  extra_notification_kwargs=None,
                                  extra_kwargs={}):
         """
@@ -506,7 +506,7 @@ class FCMNotification(BaseAPI):
                                        dry_run=False,
                                        data_message=None,
                                        content_available=None,
-                                       timeout=5,
+                                       timeout=120,
                                        extra_notification_kwargs=None,
                                        extra_kwargs={}):                                 
         """


### PR DESCRIPTION
Starting on [`v1.26.0`](https://github.com/urllib3/urllib3/releases/tag/1.26.0), urllib3 has deprecated `Retry(method_whitelist=...)` and `Retry.DEFAULT_METHOD_WHITELIST`.

> Deprecated Retry options Retry.DEFAULT_METHOD_WHITELIST, Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST
and Retry(method_whitelist=...) in favor of Retry.DEFAULT_ALLOWED_METHODS,
Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT, and Retry(allowed_methods=...)
(Pull #2000) Starting in urllib3 v2.0: Deprecated options will be removed

