### PR TITLE
Replace deprecated urllib3.Retry options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -150,3 +150,7 @@ Unreleased
 - Fix CONTRIBUTING.rst
 
 .. _Alexandr Sukhryn: https://github.com/alexsukhrin
+
+- Replace deprecated urllib3.Retry options
+
+.. _Frederico Jordan: https://github.com/fredericojordan

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -52,7 +52,7 @@ class BaseAPI(object):
         self.FCM_REQ_PROXIES = None
         self.requests_session = requests.Session()
         retries = Retry(backoff_factor=1, status_forcelist=[502, 503],
-                        method_whitelist=(Retry.DEFAULT_METHOD_WHITELIST | frozenset(['POST'])))
+                        allowed_methods=(Retry.DEFAULT_ALLOWED_METHODS | frozenset(['POST'])))
         self.requests_session.mount('http://', adapter or HTTPAdapter(max_retries=retries))
         self.requests_session.mount('https://', adapter or HTTPAdapter(max_retries=retries))
         self.requests_session.headers.update(self.request_headers())


### PR DESCRIPTION
Starting on [`v1.26.0`](https://github.com/urllib3/urllib3/releases/tag/1.26.0), urllib3 has deprecated `Retry(method_whitelist=...)` and `Retry.DEFAULT_METHOD_WHITELIST`.

> Deprecated Retry options Retry.DEFAULT_METHOD_WHITELIST, Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST
and Retry(method_whitelist=...) in favor of Retry.DEFAULT_ALLOWED_METHODS,
Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT, and Retry(allowed_methods=...)
(Pull #2000) Starting in urllib3 v2.0: Deprecated options will be removed



