### PR TITLE
urllib3 install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-install_requires = ['requests']
+install_requires = [
+    "requests",
+    "urllib3>=1.26.0",
+]
 tests_require = ['pytest']
 
 # We can't get the values using `from pyfcm import __meta__`, because this would import


### PR DESCRIPTION
Adds `urllib3>=1.26.0` to list of installation requirements.
This should fix issues like #282.