### PR TITLE
Remove annotaions for python 2.7

### DIFF
--- a/pyfcm/async_fcm.py
+++ b/pyfcm/async_fcm.py
@@ -2,7 +2,7 @@ import asyncio
 import aiohttp
 import json
 
-async def fetch_tasks(end_point:str,headers:dict,payloads:list,timeout:int):
+async def fetch_tasks(end_point,headers,payloads,timeout):
     """
 
     :param end_point (str) : FCM endpoint

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -561,7 +561,7 @@ class FCMNotification(BaseAPI):
         self.send_request([payload], timeout)
         return self.parse_responses()
 
-    def async_notify_multiple_devices(self,params_list:list=[],timeout=5):
+    def async_notify_multiple_devices(self,params_list=[],timeout=5):
         """
                 Sends push notification to multiple devices with personalized templates
 


### PR DESCRIPTION
Type hints are excluded for python 2.7 compatibility, but they remain in two places, causing an error.

https://github.com/olucurious/PyFCM/blob/master/pyfcm/fcm.py#L564
https://github.com/olucurious/PyFCM/blob/master/pyfcm/async_fcm.py#L5

issue https://github.com/olucurious/PyFCM/issues/295