### PR TITLE
raise AuthenticationError when status_code == 401

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -192,7 +192,7 @@ class BaseAPI(object):
                 return response.json()
 
         elif response.status_code == 401:
-            raise ("There was an error authenticating the sender account")
+            raise AuthenticationError("There was an error authenticating the sender account")
         elif response.status_code == 400:
             raise InvalidDataError(response.text)
         elif response.status_code == 404:


### PR DESCRIPTION
The following TypeError occurred when a 401 error occurred. 
Fixed to use AuthenticationError.

```
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.8/site-packages/pyfcm/fcm.py", line 67, in notify
    return self.parse_response(response)
  File "/layers/google.python.pip/pip/lib/python3.8/site-packages/pyfcm/baseapi.py", line 195, in parse_response
    raise ("There was an error authenticating the sender account")
TypeError: exceptions must derive from BaseException
```