### PR TITLE
fix: refresh access token

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -85,7 +85,12 @@ class BaseAPI(object):
             self.thread_local.requests_session = requests.Session()
             self.thread_local.requests_session.mount("http://", adapter)
             self.thread_local.requests_session.mount("https://", adapter)
+            self.thread_local.token_expiry = 0
+
+        current_timestamp = time.time()
+        if self.thread_local.token_expiry < current_timestamp:
             self.thread_local.requests_session.headers.update(self.request_headers())
+            self.thread_local.token_expiry = current_timestamp + 1800
         return self.thread_local.requests_session
 
     def send_request(self, payload=None, timeout=None):


### PR DESCRIPTION
fix: #334.

Supported access token refresh when it expires.
According to the [official documentation](https://cloud.google.com/apigee/docs/api-platform/antipatterns/oauth-long-expiration), access tokens expire in 30 minutes.

## checks

- [x] all tests are passed?

```
$ export GOOGLE_APPLICATION_CREDENTIALS="service_account.json"
$ export FCM_TEST_PROJECT_ID=test
$ python -m pytest

============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0
rootdir: /Users/***/Desktop/PyFCM
plugins: mock-3.14.0
collected 4 items                                                                                                                                                              

tests/test_baseapi.py ..                                                                                                                                                 [ 50%]
tests/test_fcm.py ..                                                                                                                                                     [100%]

============================================================================== 4 passed in 0.01s ===============================================================================
```