### PR TITLE
Feature: Supports credentials injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ from pyfcm import FCMNotification
 
 fcm = FCMNotification(service_account_file="<service-account-json-path>", project_id="<project-id>")
 
+# Google oauth2 credentials(such as ADC, impersonate credentials) can be used instead of service account file.
+
+fcm = FCMNotification(credentials=your_credentials, project_id="<project-id>")
+
 # OR initialize with proxies
 
 proxy_dict = {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ fcm = FCMNotification(service_account_file="<service-account-json-path>", projec
 
 # Google oauth2 credentials(such as ADC, impersonate credentials) can be used instead of service account file.
 
-fcm = FCMNotification(credentials=your_credentials, project_id="<project-id>")
+fcm = FCMNotification(
+    service_account_file=None, credentials=your_credentials, project_id="<project-id>"
+)
 
 # OR initialize with proxies
 

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -4,7 +4,7 @@ from pyfcm import FCMNotification, errors
 
 def test_push_service_without_credentials():
     try:
-        FCMNotification(service_account_file="", project_id="")
+        FCMNotification(service_account_file="", project_id="", credentials=None)
         assert False, "Should raise AuthenticationError without credentials"
     except errors.AuthenticationError:
         pass


### PR DESCRIPTION
Users may want to use prepared credentials for security reason (e.g., to avoid creating private keys for service accounts).

