### PR TITLE
Explicitly handle SENDER_ID_MISMATCH 403 error response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -158,3 +158,7 @@ Unreleased
 - Replace deprecated urllib3.Retry options v2
 
 .. _Łukasz Rogowski: https://github.com/Rogalek
+
+- Explicitly handle 403 SENDER_ID_MISMATCH response
+
+.. _James Priebe: https://github.com/J-Priebe/

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -186,7 +186,7 @@ class BaseAPI(object):
         Parses the json response sent back by the server and tries to get out the important return variables
 
         Returns:
-            dict: name (str) - uThe identifier of the message sent, in the format of projects/*/messages/{message_id}
+            dict: name (str) - The identifier of the message sent, in the format of projects/*/messages/{message_id}
 
         Raises:
             FCMServerError: FCM is temporary not available

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -16,6 +16,7 @@ from pyfcm.errors import (
     AuthenticationError,
     InvalidDataError,
     FCMError,
+    FCMSenderIdMismatchError,
     FCMServerError,
     FCMNotRegisteredError,
 )
@@ -210,6 +211,10 @@ class BaseAPI(object):
             )
         elif response.status_code == 400:
             raise InvalidDataError(response.text)
+        elif response.status_code == 403:
+            raise FCMSenderIdMismatchError(
+                "The authenticated sender ID is different from the sender ID for the registration token."
+            )
         elif response.status_code == 404:
             raise FCMNotRegisteredError("Token not registered")
         else:

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -192,6 +192,8 @@ class BaseAPI(object):
             FCMServerError: FCM is temporary not available
             AuthenticationError: error authenticating the sender account
             InvalidDataError: data passed to FCM was incorrecly structured
+            FCMSenderIdMismatchError: the authenticated sender is different from the sender registered to the token
+            FCMNotRegisteredError: device token is missing, not registered, or invalid
         """
 
         if response.status_code == 200:

--- a/pyfcm/errors.py
+++ b/pyfcm/errors.py
@@ -23,6 +23,15 @@ class FCMNotRegisteredError(FCMError):
     pass
 
 
+class FCMSenderIdMismatchError(FCMError):
+    """
+    Sender is not allowed for the given device tokens
+    https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+    """
+
+    pass
+
+
 class FCMServerError(FCMError):
     """
     Internal server error or timeout error on Firebase cloud messaging server

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -41,7 +41,7 @@ class FCMNotification(BaseAPI):
             timeout (int, optional): Set time limit for the request
 
         Returns:
-            dict: Response from FCM server (`multicast_id`, `success`, `failure`, `canonical_ids`, `results`)
+            dict: name (str) - uThe identifier of the message sent, in the format of projects/*/messages/{message_id}
 
         Raises:
             AuthenticationError: If api_key is not set or provided or there is an error authenticating the sender.

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -44,10 +44,11 @@ class FCMNotification(BaseAPI):
             dict: name (str) - The identifier of the message sent, in the format of projects/*/messages/{message_id}
 
         Raises:
-            AuthenticationError: If api_key is not set or provided or there is an error authenticating the sender.
-            FCMServerError: Internal server error or timeout error on Firebase cloud messaging server
-            InvalidDataError: Invalid data provided
-            InternalPackageError: Mostly from changes in the response of FCM, contact the project owner to resolve the issue
+            FCMServerError: FCM is temporary not available
+            AuthenticationError: error authenticating the sender account
+            InvalidDataError: data passed to FCM was incorrecly structured
+            FCMSenderIdMismatchError: the authenticated sender is different from the sender registered to the token
+            FCMNotRegisteredError: device token is missing, not registered, or invalid
         """
         payload = self.parse_payload(
             fcm_token=fcm_token,

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -41,7 +41,7 @@ class FCMNotification(BaseAPI):
             timeout (int, optional): Set time limit for the request
 
         Returns:
-            dict: name (str) - uThe identifier of the message sent, in the format of projects/*/messages/{message_id}
+            dict: name (str) - The identifier of the message sent, in the format of projects/*/messages/{message_id}
 
         Raises:
             AuthenticationError: If api_key is not set or provided or there is an error authenticating the sender.


### PR DESCRIPTION
Small additional check to separate 403s from generic `FCMServerError`. Also updates the `notify` docstring in line with the changes to `parse_response` in 2.x