### PR TITLE
:zap: Support for multiplexing with HTTP/2, and HTTP/3 using Niquests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,3 +162,7 @@ Unreleased
 - Explicitly handle 403 SENDER_ID_MISMATCH response
 
 .. _James Priebe: https://github.com/J-Priebe/
+
+- Replace Requests and Aiohttp by Niquests. Support for HTTP/2, and HTTP/3 with advanced multiplexing.
+
+.. _Ahmed Tahri: https://github.com/Ousret

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-aiohttp>=3.8.6
 cachetools==5.3.3
 google-auth==2.22.0
 pyasn1==0.6.0
 pyasn1-modules==0.4.0
 rsa==4.9
-requests>=2.6.0
-urllib3==1.26.19
+niquests>=3.11,<4
 pytest-mock==3.14.0

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,8 @@ def read(fname):
 
 
 install_requires = [
-    "requests",
-    "urllib3>=1.26.0",
+    "niquests>=3.11,<4",
     "google-auth>=2.22.0",
-    "aiohttp>=3.8.6",
 ]
 tests_require = ["pytest"]
 
@@ -63,13 +61,13 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,7 @@ def mock_aiohttp_session(mocker):
     response = {"test": "test"}
 
     # Create a mock response object
-    mock_response = AsyncMock()
-    mock_response.text = AsyncMock(return_value=json.dumps(response))
-    mock_response.status = 200
-    mock_response.headers = {"Content-Length": "123"}
+    mock_response = AsyncMock(return_value=json.dumps(response))
 
     mock_send = mocker.patch("pyfcm.async_fcm.send_request", new_callable=AsyncMock)
     mock_send.return_value = mock_response


### PR DESCRIPTION
Hello,

This will greatly improve performance by bringing true HTTP/2, and HTTP/3 support. No longer will you need thousands of connections via crafted loop inside a sync context to achieve high concurrency.

This effectively makes async_fcm.py useless. We should consider adding true async classes sometime later.

