### PR TITLE
Fix type hint on BaseAPI.__init__

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -28,11 +28,11 @@ class BaseAPI(object):
 
     def __init__(
         self,
-        service_account_file: str = None,
-        project_id: str = None,
+        service_account_file: str | None = None,
+        project_id: str | None = None,
         credentials: Credentials | None = None,
-        proxy_dict=None,
-        env=None,
+        proxy_dict: dict | None = None,
+        env: str | None = None,
         json_encoder=None,
         adapter=None,
     ):

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -30,7 +30,7 @@ class BaseAPI(object):
         self,
         service_account_file: str = None,
         project_id: str = None,
-        credentials: Credentials = None,
+        credentials: Credentials | None = None,
         proxy_dict=None,
         env=None,
         json_encoder=None,

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -286,9 +286,7 @@ class BaseAPI(object):
             else:
                 raise InvalidDataError("Provided fcm_options is in the wrong format")
 
-        fcm_payload[
-            "notification"
-        ] = (
+        fcm_payload["notification"] = (
             {}
         )  # - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification
         # If title is present, use it


### PR DESCRIPTION
The parameter `credentials` is None by default, but the type hint is set to only `Credentials`. This PR changes the type hint to account for the possibility of `None`