### PR TITLE
feat: refresh access token when expired

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -315,9 +315,7 @@ class BaseAPI(object):
             else:
                 raise InvalidDataError("Provided fcm_options is in the wrong format")
 
-        fcm_payload[
-            "notification"
-        ] = (
+        fcm_payload["notification"] = (
             {}
         )  # - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification
         # If title is present, use it

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import pytest
 
 from pyfcm import errors
@@ -48,3 +49,96 @@ def test_parse_payload(base_api):
     }
 
     assert data["message"]["data"] == {"test": "test"}
+
+
+def test_send_request_normal(base_api, mocker):
+    """Test that send_request called once on success"""
+
+    success_response = mocker.Mock()
+    success_response.headers = {}
+
+    mock_session = mocker.Mock()
+    mock_session.post.side_effect = [success_response]
+
+    base_api.thread_local = mocker.Mock()
+    base_api.thread_local.requests_session = mock_session
+    base_api.thread_local.token_expiry = time.time() + 1000
+
+    # do
+    result = base_api.send_request(payload="test_payload", timeout=30)
+
+    # check
+    assert mock_session.post.call_count == 1
+    assert result == success_response
+
+
+def test_send_request_retry_after(base_api, mocker):
+    """Test that send_request retries when Retry-After header is present"""
+
+    # Mock time.sleep to avoid actual delays
+    mock_sleep = mocker.patch('time.sleep')
+
+    retry_response = mocker.Mock()
+    retry_response.headers = {"Retry-After": "2"}
+
+    success_response = mocker.Mock()
+    success_response.headers = {}
+
+    mock_session = mocker.Mock()
+    mock_session.post.side_effect = [retry_response, success_response]
+
+    base_api.thread_local = mocker.Mock()
+    base_api.thread_local.requests_session = mock_session
+    base_api.thread_local.token_expiry = time.time() + 1000
+
+    # do
+    result = base_api.send_request(payload="test_payload", timeout=30)
+
+    # check
+    assert mock_session.post.call_count == 2
+    mock_sleep.assert_called_once_with(2)
+    assert result == success_response
+
+
+def test_send_request_access_token_expired_retry(base_api, mocker):
+    """Test that send_request retries when ACCESS_TOKEN_EXPIRED error occurs"""
+
+    # Mock the expired token response
+    EXPIRED_STATUS_CODE = 401
+    expired_response = mocker.Mock()
+    expired_response.status_code = EXPIRED_STATUS_CODE
+    expired_response.headers = {}
+    expired_response.json.return_value = {
+        "error": {
+            "code": EXPIRED_STATUS_CODE,
+            "message": "Request had invalid authentication credentials.",
+            "status": "UNAUTHENTICATED",
+            "details": [
+                {
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": "ACCESS_TOKEN_EXPIRED",
+                    "domain": "googleapis.com"
+                }
+            ]
+        }
+    }
+
+    success_response = mocker.Mock()
+    success_response.status_code = 200
+    success_response.headers = {}
+
+    mock_session = mocker.Mock()
+    mock_session.post.side_effect = [expired_response, success_response]
+
+    mock_requests_session = mocker.patch.object(
+        type(base_api), 'requests_session', new_callable=mocker.PropertyMock
+    )
+    mock_requests_session.return_value = mock_session
+
+    # do
+    result = base_api.send_request(payload="test_payload", timeout=30)
+
+    # check
+    assert mock_session.post.call_count == 2
+    assert base_api.thread_local.token_expiry == 0
+    assert result == success_response

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -76,7 +76,7 @@ def test_send_request_retry_after(base_api, mocker):
     """Test that send_request retries when Retry-After header is present"""
 
     # Mock time.sleep to avoid actual delays
-    mock_sleep = mocker.patch('time.sleep')
+    mock_sleep = mocker.patch("time.sleep")
 
     retry_response = mocker.Mock()
     retry_response.headers = {"Retry-After": "2"}
@@ -117,9 +117,9 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
                 {
                     "@type": "type.googleapis.com/google.rpc.ErrorInfo",
                     "reason": "ACCESS_TOKEN_EXPIRED",
-                    "domain": "googleapis.com"
+                    "domain": "googleapis.com",
                 }
-            ]
+            ],
         }
     }
 
@@ -131,7 +131,7 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
     mock_session.post.side_effect = [expired_response, success_response]
 
     mock_requests_session = mocker.patch.object(
-        type(base_api), 'requests_session', new_callable=mocker.PropertyMock
+        type(base_api), "requests_session", new_callable=mocker.PropertyMock
     )
     mock_requests_session.return_value = mock_session
 


### PR DESCRIPTION
Related: #334

Implements automatic access token refresh functionality when tokens expire during FCM API requests.

When 401 error responses with reason:ACCESS_TOKEN_EXPIRED, retry another request.

## checks

- [x] all tests are passed?

```bash
python -m pytest
======================================== test session starts ========================================
platform darwin -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/niccari/Desktop/PyFCM
plugins: mock-3.14.1
collected 8 items                                                                                   

tests/test_baseapi.py .....                                                                   [ 62%]
tests/test_fcm.py ...                                                                         [100%]

========================================= 8 passed in 0.01s =========================================
```

## 401 with ACCESS_TOKEN_EXPIRED error response example

```json
{
  "error": {
    "code": 401,
    "message": "Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.",
    "status": "UNAUTHENTICATED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "ACCESS_TOKEN_EXPIRED",
        "domain": "googleapis.com",
        "metadata": {
          "method": "google.firebase.fcm.v1.FcmService.SendMessage",
          "service": "fcm.googleapis.com"
        }
      }
    ]
  }
}
```