### PR TITLE
Fix: applied code formatting (flake8, black)

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -224,10 +224,11 @@ class BaseAPI(object):
             raise FCMNotRegisteredError("Token not registered")
         else:
             raise FCMServerError(
-                f"FCM server error: Unexpected status code {response.status_code}. The server might be temporarily unavailable."
+                f"FCM server error: Unexpected status code {response.status_code}. "
+                "The server might be temporarily unavailable."
             )
 
-    def parse_payload(
+    def parse_payload(  # noqa: C901
         self,
         fcm_token=None,
         notification_title=None,

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -286,9 +286,7 @@ class BaseAPI(object):
             else:
                 raise InvalidDataError("Provided fcm_options is in the wrong format")
 
-        fcm_payload[
-            "notification"
-        ] = (
+        fcm_payload["notification"] = (
             {}
         )  # - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification
         # If title is present, use it

--- a/pyfcm/fcm.py
+++ b/pyfcm/fcm.py
@@ -1,5 +1,4 @@
 from .baseapi import BaseAPI
-from .errors import InvalidDataError
 
 
 class FCMNotification(BaseAPI):
@@ -33,10 +32,14 @@ class FCMNotification(BaseAPI):
             topic_name (str, optional): Name of the topic to deliver messages to e.g. "weather".
             topic_condition (str, optional): Condition to broadcast a message to, e.g. "'foo' in topics && 'bar' in topics".
 
-            android_config (dict, optional): Android specific options for messages - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
-            apns_config (dict, optional): Apple Push Notification Service specific options - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#apnsconfig
-            webpush_config (dict, optional): Webpush protocol options - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig
-            fcm_options (dict, optional): Platform independent options for features provided by the FCM SDKs - https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#fcmoptions
+            android_config (dict, optional): Android specific options for messages -
+                https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
+            apns_config (dict, optional): Apple Push Notification Service specific options -
+                https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#apnsconfig
+            webpush_config (dict, optional): Webpush protocol options -
+                https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushconfig
+            fcm_options (dict, optional): Platform independent options for features provided by the FCM SDKs -
+                https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#fcmoptions
 
             timeout (int, optional): Set time limit for the request
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from pyfcm import FCMNotification, errors
+from pyfcm import FCMNotification
 from pyfcm.baseapi import BaseAPI
 
 

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -2,7 +2,6 @@ import os
 import json
 import pytest
 
-from pyfcm import errors
 from pyfcm.baseapi import BaseAPI
 
 

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -1,4 +1,3 @@
-import pytest
 from pyfcm import FCMNotification, errors
 import os
 from google.oauth2 import service_account


### PR DESCRIPTION
Fixed an issue pointed out by flake8 warnings/errors where workflows would fail on Github Actions as shown in #366 .

## Checks
- [x] flake8 now reports no issues.
- [x] After running black, no code differences occur.
- [x] All unit test has been passed.