### PR TITLE
feat: lazy load service-account private key until it needed - unit test does not requires credentials setting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,35 +28,11 @@ Some simple guidelines to follow when contributing code:
 Tests
 -----
 
-Before commiting your changes, please run the tests. For running the tests you need service account credentials in a JSON file.
-These do NOT have to be real credentials, but must have a properly encoded private key. You can create a key for testing using a site
-like `cryptotools <https://cryptotools.net/rsagen/>`_ . For example:
-
-::
-
-    {
-        "type": "service_account",
-        "project_id": "splendid-donkey-123",
-        "private_key_id": "12345",
-        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMYTESTKEY\n-----END RSA PRIVATE KEY-----",
-        "client_email": "firebase-adminsdk@splendid-donkey-123.iam.gserviceaccount.com",
-        "client_id": "789",
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://oauth2.googleapis.com/token",
-        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-splendid-donkey-123.iam.gserviceaccount.com",
-        "universe_domain": "googleapis.com"
-    }
-
-**Please do not use a service account or private key, which is used in production!**
+Before commiting your changes, please run the tests. 
 
 ::
 
     pip install . ".[test]"
-
-    export GOOGLE_APPLICATION_CREDENTIALS="path/to/service_account.json"
-    export FCM_TEST_PROJECT_ID="test-project-id"
-
     python -m pytest
 
 If you add a new fixture or fix a bug, please make sure to write a new unit test. This makes development easier and avoids new bugs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,25 @@
 import json
-import os
 from unittest.mock import AsyncMock
 
 import pytest
 
 from pyfcm import FCMNotification
 from pyfcm.baseapi import BaseAPI
+from google.auth.credentials import Credentials
+
+
+class DummyCredentials(Credentials):
+    def refresh():
+        pass
+
+    @property
+    def project_id(self):
+        return "test"
 
 
 @pytest.fixture(scope="module")
 def push_service():
-    service_account_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", None)
-    project_id = os.getenv("FCM_TEST_PROJECT_ID", None)
-    assert (
-        service_account_file
-    ), "Please set the service_account for testing according to CONTRIBUTING.rst"
-
-    return FCMNotification(
-        service_account_file=service_account_file, project_id=project_id
-    )
+    return FCMNotification(credentials=DummyCredentials())
 
 
 @pytest.fixture
@@ -49,9 +50,4 @@ def mock_aiohttp_session(mocker):
 
 @pytest.fixture(scope="module")
 def base_api():
-    service_account = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", None)
-    assert (
-        service_account
-    ), "Please set the service_account for testing according to CONTRIBUTING.rst"
-
-    return BaseAPI(api_key=service_account)
+    return BaseAPI(credentials=DummyCredentials())

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,20 +1,5 @@
-import os
 import json
 import time
-import pytest
-
-from pyfcm.baseapi import BaseAPI
-
-
-@pytest.fixture(scope="module")
-def base_api():
-    service_account_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", None)
-    project_id = os.getenv("FCM_TEST_PROJECT_ID", None)
-    assert (
-        project_id
-    ), "Please set the environment variables for testing according to CONTRIBUTING.rst"
-
-    return BaseAPI(service_account_file=service_account_file, project_id=project_id)
 
 
 def test_json_dumps(base_api):

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -1,29 +1,20 @@
 from pyfcm import FCMNotification, errors
-import os
-from google.oauth2 import service_account
 
 
 def test_push_service_without_credentials():
     try:
-        FCMNotification(service_account_file="", project_id="", credentials=None)
+        FCMNotification(service_account_file=None, project_id=None, credentials=None)
         assert False, "Should raise AuthenticationError without credentials"
     except errors.AuthenticationError:
         pass
 
 
-def test_push_service_directly_passed_credentials():
-    service_account_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", None)
-    credentials = service_account.Credentials.from_service_account_file(
-        service_account_file,
-        scopes=["https://www.googleapis.com/auth/firebase.messaging"],
-    )
-    push_service = FCMNotification(credentials=credentials)
-
+def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials
     # without the need to explcitily pass it
     assert push_service.fcm_end_point == (
         "https://fcm.googleapis.com/v1/projects/"
-        f"{credentials.project_id}/messages:send"
+        f"{push_service.credentials.project_id}/messages:send"
     )
 
 


### PR DESCRIPTION
fixes unit test issue at https://github.com/olucurious/PyFCM/actions/runs/16545059983/job/46791440559

This PR defers credentials loads until it needed, unit tests now run without requiring credentials setting.