### PR TITLE
fix: requirements.txt, match master's urllib3 version (2.5.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 aiohttp>=3.8.6
-cachetools==5.3.3
-google-auth==2.22.0
-pyasn1==0.6.0
-pyasn1-modules==0.4.0
-rsa==4.9
+cachetools==5.5.2
+google-auth==2.24.0
+pyasn1==0.6.1
+pyasn1-modules==0.4.2
+rsa==4.9.1
 requests>=2.6.0
-urllib3==1.26.19
-pytest-mock==3.14.0
+urllib3==2.5.0
+pytest-mock==3.14.1


### PR DESCRIPTION
This PR fixes requirements.txt conflict between urllib3 and google-auth in the master branch.

- Updated google-auth to 2.24.0, compatible with urllib3 > 2 and python 3.12.
- Updated urllib3 to 2.5.0, same version as main branch (https://github.com/olucurious/PyFCM/commit/6b9205e51cc37a71787736561bd774a93eb37bc4).

## Checks
- [x] All unit test has been passed.

```bash
=================================================================== test session starts ====================================================================
platform darwin -- Python 3.10.18, pytest-8.4.1, pluggy-1.6.0
plugins: mock-3.14.1
collected 8 items                                                                                                                                          

tests/test_baseapi.py .....                                                                                                                          [ 62%]
tests/test_fcm.py ...                                                                                                                                [100%]

==================================================================== 8 passed in 0.02s =====================================================================
```
