### PR TITLE
fix: Credentials type should be google.auth.credentials.Credentials

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,24 +2,20 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from google.auth.credentials import Credentials
 
 from pyfcm import FCMNotification
 from pyfcm.baseapi import BaseAPI
-from google.auth.credentials import Credentials
 
 
 class DummyCredentials(Credentials):
-    def refresh():
+    def refresh(self, request):
         pass
 
-    @property
-    def project_id(self):
-        return "test"
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def push_service():
-    return FCMNotification(credentials=DummyCredentials())
+    return FCMNotification(credentials=DummyCredentials(), project_id="test")
 
 
 @pytest.fixture
@@ -48,6 +44,6 @@ def mock_aiohttp_session(mocker):
     return mock_send
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def base_api():
-    return BaseAPI(credentials=DummyCredentials())
+    return BaseAPI(credentials=DummyCredentials(), project_id="test")

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,6 +1,15 @@
 import json
 import time
 
+import pytest
+
+
+def test_empty_project_id(base_api):
+    base_api._project_id = None
+    with pytest.raises(RuntimeError) as e:
+        base_api.fcm_end_point
+    assert str(e.value) == "Please provide a project_id either explicitly or through Google credentials."
+
 
 def test_json_dumps(base_api):
     json_string = base_api.json_dumps([{"test": "Test"}, {"test2": "Test2"}])

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -12,9 +12,9 @@ def test_push_service_without_credentials():
 def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials
     # without the need to explcitily pass it
+    push_service._project_id = "abc123"
     assert push_service.fcm_end_point == (
-        "https://fcm.googleapis.com/v1/projects/"
-        f"{push_service.credentials.project_id}/messages:send"
+        "https://fcm.googleapis.com/v1/projects/abc123/messages:send"
     )
 
 


### PR DESCRIPTION
Fixes #367 

The type of credentials assigned during initialization has been changed to "google.auth.credentials.Credentials".

The credentials that users assign to BaseAPI come in a variety of types, including Application Default Credentials and Impersonated Credentials.
These credentials inherit from google.auth.credentials.Credentials.

## Checks
- [x] flake8 reports no issues
- [x] all unit tests have passed