### PR TITLE
[WIP] Making access token management thread-safe

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -4,15 +4,12 @@ from functools import cached_property
 import json
 import time
 import threading
-from datetime import datetime, timedelta, timezone
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-from google.oauth2 import service_account
 from google.auth.credentials import Credentials
-import google.auth.transport.requests
 
 from pyfcm.errors import (
     AuthenticationError,
@@ -21,6 +18,7 @@ from pyfcm.errors import (
     FCMServerError,
     FCMNotRegisteredError,
 )
+from pyfcm.token_manager import TokenManager
 
 # Migration to v1 - https://firebase.google.com/docs/cloud-messaging/migrate-v1
 
@@ -49,20 +47,13 @@ class BaseAPI(object):
             json_encoder (BaseJSONEncoder): JSON encoder
             adapter (BaseAdapter): adapter instance
         """
-        if not (service_account_file or credentials):
-            raise AuthenticationError(
-                "Please provide a service account file path or credentials in the constructor"
-            )
-
-        self._service_account_file = service_account_file
-        self._project_id = project_id
-        self._provided_credentials = credentials
+        self.token_manager = TokenManager(
+            service_account_file=service_account_file,
+            project_id=project_id,
+            credentials=credentials,
+        )
         self.custom_adapter = adapter
         self.thread_local = threading.local()
-
-        # Shared token management across threads
-        self._shared_token = None
-        self._token_lock = threading.RLock()
 
         if (
             proxy_dict
@@ -82,27 +73,10 @@ class BaseAPI(object):
         self.json_encoder = json_encoder
 
     @cached_property
-    def _credentials(self) -> Credentials:
-        if self._provided_credentials is not None:
-            return self._provided_credentials
-
-        credentials = service_account.Credentials.from_service_account_file(
-            self._service_account_file,
-            scopes=["https://www.googleapis.com/auth/firebase.messaging"],
-        )
-        # Service account credentials has project_id (others are not)
-        self._project_id = credentials.project_id or self._project_id
-        self._service_account_file = None
-        return credentials
-
-    @cached_property
     def fcm_end_point(self) -> str:
-        if self._provided_credentials is None:
-            # read credentails to resolve project_id if needed
-            _ = self._credentials
-        if self._project_id is None:
-            raise RuntimeError("Please provide a project_id either explicitly or through Google credentials.")
-        return self.FCM_END_POINT_BASE + f"/{self._project_id}/messages:send"
+        return (
+            self.FCM_END_POINT_BASE + f"/{self.token_manager.project_id}/messages:send"
+        )
 
     @property
     def requests_session(self):
@@ -134,16 +108,7 @@ class BaseAPI(object):
             return self.send_request(payload, timeout)
 
         if self._is_access_token_expired(response):
-            # Clear shared token and refresh credentials
-            with self._token_lock:
-                self._shared_token = None
-                if self._credentials:
-                    try:
-                        request = google.auth.transport.requests.Request()
-                        self._credentials.refresh(request)
-                    except Exception:
-                        # If refresh fails, let the next request handle it
-                        pass
+            self.token_manager.refresh_token_if_expired()
             return self.send_request(payload, timeout)
 
         return response
@@ -188,53 +153,6 @@ class BaseAPI(object):
 
         return False
 
-    def _is_token_valid(self) -> bool:
-        """
-        Enhanced token validity check with fallback mechanisms.
-        Combines expired property check with time-based validation.
-
-        Returns:
-            bool: True if token is valid, False otherwise
-        """
-        if not self._shared_token:
-            return False
-
-        if self._credentials.expired:
-            return False
-
-        # Fallback check: time-based validation with 5-minute buffer
-        # This accounts for the 4-minute early expiration issue
-        if (hasattr(self._credentials, 'expiry') and
-                self._credentials.expiry and
-                self._credentials.expiry <= datetime.now(timezone.utc) + timedelta(minutes=5)):
-            return False
-
-        return True
-
-    def _get_access_token(self) -> str:
-        """
-        Thread-safe access token management with shared token across threads.
-        Uses double-checked locking pattern for performance with enhanced validation.
-        Returns:
-             str: Access token
-        """
-        # First check without lock (performance optimization)
-        if self._is_token_valid():
-            return self._shared_token
-
-        # Acquire lock and check again (double-checked locking)
-        with self._token_lock:
-            if self._is_token_valid():
-                return self._shared_token
-
-            try:
-                request = google.auth.transport.requests.Request()
-                self._credentials.refresh(request)
-                self._shared_token = self._credentials.token
-                return self._shared_token
-            except Exception as e:
-                raise InvalidDataError(e)
-
     def request_headers(self):
         """
         Generates request headers including Content-Type and Authorization of Bearer token
@@ -244,7 +162,7 @@ class BaseAPI(object):
         """
         return {
             "Content-Type": "application/json",
-            "Authorization": "Bearer " + self._get_access_token(),
+            "Authorization": "Bearer " + self.token_manager.get_access_token(),
         }
 
     def json_dumps(self, data):

--- a/pyfcm/token_manager.py
+++ b/pyfcm/token_manager.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 import threading
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from google.oauth2 import service_account
 from google.auth.credentials import Credentials
@@ -17,9 +18,9 @@ class TokenManager:
 
     def __init__(
         self,
-        service_account_file: str | None = None,
-        project_id: str | None = None,
-        credentials: Credentials | None = None,
+        service_account_file: Optional[str] = None,
+        project_id: Optional[str] = None,
+        credentials: Optional[Credentials] = None,
     ):
         """
         Initialize TokenManager

--- a/pyfcm/token_manager.py
+++ b/pyfcm/token_manager.py
@@ -1,0 +1,150 @@
+from functools import cached_property
+import threading
+from datetime import datetime, timedelta, timezone
+
+from google.oauth2 import service_account
+from google.auth.credentials import Credentials
+import google.auth.transport.requests
+
+from pyfcm.errors import AuthenticationError, InvalidDataError
+
+
+class TokenManager:
+    """
+    Token management class extracted from BaseAPI.
+    Handles authentication credentials and access token lifecycle.
+    """
+
+    def __init__(
+        self,
+        service_account_file: str | None = None,
+        project_id: str | None = None,
+        credentials: Credentials | None = None,
+    ):
+        """
+        Initialize TokenManager
+
+        Args:
+            service_account_file (str): path to service account JSON file
+            project_id (str): project ID of Google account
+            credentials (Credentials): Google auth credentials instance
+        """
+        if not (service_account_file or credentials):
+            raise AuthenticationError(
+                "Please provide a service account file path or credentials in the constructor"
+            )
+
+        self._service_account_file = service_account_file
+        self._project_id = project_id
+        self._provided_credentials = credentials
+
+        # Shared token management across threads
+        self._shared_token = None
+        self._token_lock = threading.RLock()
+
+    @cached_property
+    def _credentials(self) -> Credentials:
+        """
+        Get authentication credentials
+
+        Returns:
+            Credentials: Google authentication credentials
+        """
+        if self._provided_credentials is not None:
+            return self._provided_credentials
+
+        credentials = service_account.Credentials.from_service_account_file(
+            self._service_account_file,
+            scopes=["https://www.googleapis.com/auth/firebase.messaging"],
+        )
+        # Service account credentials has project_id (others are not)
+        self._project_id = credentials.project_id or self._project_id
+        self._service_account_file = None
+        return credentials
+
+    @cached_property
+    def project_id(self) -> str:
+        """
+        Get project ID
+
+        Returns:
+            str: Project ID
+
+        Raises:
+            RuntimeError: If project_id is not configured
+        """
+        # Read credentials to resolve project_id if needed
+        _ = self._credentials
+        if self._project_id is None:
+            raise RuntimeError(
+                "Please provide a project_id either explicitly or through Google credentials."
+            )
+        return self._project_id
+
+    def _is_token_valid(self) -> bool:
+        """
+        Enhanced token validity check with fallback mechanisms.
+        Combines expired property check with time-based validation.
+
+        Returns:
+            bool: True if token is valid, False otherwise
+        """
+        if not self._shared_token:
+            return False
+
+        if self._credentials.expired:
+            return False
+
+        # Fallback check: time-based validation with 5-minute buffer
+        # This accounts for the 4-minute early expiration issue
+        if (
+            hasattr(self._credentials, "expiry")
+            and self._credentials.expiry
+            and self._credentials.expiry
+            <= datetime.now(timezone.utc) + timedelta(minutes=5)
+        ):
+            return False
+
+        return True
+
+    def get_access_token(self) -> str:
+        """
+        Thread-safe access token management with shared token across threads.
+        Uses double-checked locking pattern for performance with enhanced validation.
+
+        Returns:
+            str: Access token
+
+        Raises:
+            InvalidDataError: If token acquisition fails
+        """
+        # First check without lock (performance optimization)
+        if self._is_token_valid():
+            return self._shared_token
+
+        # Acquire lock and check again (double-checked locking)
+        with self._token_lock:
+            if self._is_token_valid():
+                return self._shared_token
+
+            try:
+                request = google.auth.transport.requests.Request()
+                self._credentials.refresh(request)
+                self._shared_token = self._credentials.token
+                return self._shared_token
+            except Exception as e:
+                raise InvalidDataError(e)
+
+    def refresh_token_if_expired(self) -> None:
+        """
+        Refresh token if needed
+        """
+        with self._token_lock:
+            self._shared_token = None
+            if self._credentials:
+                try:
+                    request = google.auth.transport.requests.Request()
+                    self._credentials.refresh(request)
+                except Exception:
+                    # If refresh fails, let the next request handle it
+                    pass

--- a/pyfcm/token_manager.py
+++ b/pyfcm/token_manager.py
@@ -142,10 +142,10 @@ class TokenManager:
         """
         with self._token_lock:
             self._shared_token = None
-            if self._credentials:
-                try:
-                    request = google.auth.transport.requests.Request()
-                    self._credentials.refresh(request)
-                except Exception:
-                    # If refresh fails, let the next request handle it
-                    pass
+            try:
+                request = google.auth.transport.requests.Request()
+                self._credentials.refresh(request)
+                self._shared_token = self._credentials.token
+            except Exception:
+                # If refresh fails, let the next request handle it
+                pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,17 @@ from pyfcm.baseapi import BaseAPI
 
 
 class DummyCredentials(Credentials):
+    def __init__(self):
+        self.token = "dummy_token"
+        self._expired = True
+
     def refresh(self, request):
-        pass
+        self.token = "refreshed_dummy_token"
+        self._expired = False
+
+    @property
+    def expired(self):
+        return self._expired
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,24 +2,20 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from google.auth.credentials import Credentials
 
 from pyfcm import FCMNotification
 from pyfcm.baseapi import BaseAPI
-from google.auth.credentials import Credentials
 
 
 class DummyCredentials(Credentials):
-    def refresh():
+    def refresh(self, request):
         pass
 
-    @property
-    def project_id(self):
-        return "test"
 
-
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def push_service():
-    return FCMNotification(credentials=DummyCredentials())
+    return FCMNotification(credentials=DummyCredentials(), project_id="test")
 
 
 @pytest.fixture
@@ -48,6 +44,6 @@ def mock_aiohttp_session(mocker):
     return mock_send
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def base_api():
-    return BaseAPI(credentials=DummyCredentials())
+    return BaseAPI(credentials=DummyCredentials(), project_id="test")

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,6 +1,15 @@
 import json
 import time
 
+import pytest
+
+
+def test_empty_project_id(base_api):
+    base_api._project_id = None
+    with pytest.raises(RuntimeError) as e:
+        base_api.fcm_end_point
+    assert str(e.value) == "Please provide a project_id either explicitly or through Google credentials."
+
 
 def test_json_dumps(base_api):
     json_string = base_api.json_dumps([{"test": "Test"}, {"test2": "Test2"}])

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -4,10 +4,13 @@ import pytest
 
 
 def test_empty_project_id(base_api):
-    base_api._project_id = None
+    base_api.token_manager._project_id = None
     with pytest.raises(RuntimeError) as e:
         base_api.fcm_end_point
-    assert str(e.value) == "Please provide a project_id either explicitly or through Google credentials."
+    assert (
+        str(e.value)
+        == "Please provide a project_id either explicitly or through Google credentials."
+    )
 
 
 def test_json_dumps(base_api):
@@ -124,8 +127,8 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
         type(base_api), "requests_session", new_callable=mocker.PropertyMock
     )
     mock_requests_session.return_value = mock_session
-    base_api._shared_token = "dummy"
-    assert base_api._shared_token is not None
+    base_api.token_manager._shared_token = "dummy"
+    assert base_api.token_manager._shared_token is not None
 
     # do
     result = base_api.send_request(payload="test_payload", timeout=30)
@@ -133,5 +136,5 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
     # check
     assert mock_session.post.call_count == 2
     # token cleared, but not refreshed because request_session is mocked
-    assert base_api._shared_token is None
+    assert base_api.token_manager._shared_token is None
     assert result == success_response

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 import pytest
 
@@ -55,7 +54,6 @@ def test_send_request_normal(base_api, mocker):
 
     base_api.thread_local = mocker.Mock()
     base_api.thread_local.requests_session = mock_session
-    base_api.thread_local.token_expiry = time.time() + 1000
 
     # do
     result = base_api.send_request(payload="test_payload", timeout=30)
@@ -82,7 +80,6 @@ def test_send_request_retry_after(base_api, mocker):
 
     base_api.thread_local = mocker.Mock()
     base_api.thread_local.requests_session = mock_session
-    base_api.thread_local.token_expiry = time.time() + 1000
 
     # do
     result = base_api.send_request(payload="test_payload", timeout=30)
@@ -127,11 +124,14 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
         type(base_api), "requests_session", new_callable=mocker.PropertyMock
     )
     mock_requests_session.return_value = mock_session
+    base_api._shared_token = "dummy"
+    assert base_api._shared_token is not None
 
     # do
     result = base_api.send_request(payload="test_payload", timeout=30)
 
     # check
     assert mock_session.post.call_count == 2
-    assert base_api.thread_local.token_expiry == 0
+    # token cleared, but not refreshed because request_session is mocked
+    assert base_api._shared_token is None
     assert result == success_response

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -135,6 +135,5 @@ def test_send_request_access_token_expired_retry(base_api, mocker):
 
     # check
     assert mock_session.post.call_count == 2
-    # token cleared, but not refreshed because request_session is mocked
-    assert base_api.token_manager._shared_token is None
+    assert base_api.token_manager._shared_token == "refreshed_dummy_token"
     assert result == success_response

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -12,7 +12,7 @@ def test_push_service_without_credentials():
 def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials
     # without the need to explcitily pass it
-    push_service._project_id = "abc123"
+    push_service.token_manager._project_id = "abc123"
     assert push_service.fcm_end_point == (
         "https://fcm.googleapis.com/v1/projects/abc123/messages:send"
     )

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -12,9 +12,9 @@ def test_push_service_without_credentials():
 def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials
     # without the need to explcitily pass it
+    push_service._project_id = "abc123"
     assert push_service.fcm_end_point == (
-        "https://fcm.googleapis.com/v1/projects/"
-        f"{push_service.credentials.project_id}/messages:send"
+        "https://fcm.googleapis.com/v1/projects/abc123/messages:send"
     )
 
 

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,0 +1,104 @@
+import threading
+
+import pytest
+from google.auth.credentials import Credentials
+
+from pyfcm.errors import InvalidDataError
+from pyfcm.token_manager import TokenManager
+
+
+class DummyCredentials(Credentials):
+    def __init__(self):
+        self.token = "initial_token"
+        self._expired = True
+
+    def refresh(self, request):
+        self.token = "refreshed_token"
+        self._expired = False
+
+    @property
+    def expired(self):
+        return self._expired
+
+
+@pytest.fixture
+def token_manager():
+    return TokenManager(credentials=DummyCredentials(), project_id="test")
+
+
+class TestRefreshTokenIfExpired:
+    def test_updates_shared_token_after_refresh(self, token_manager):
+        """Regression: refresh_token_if_expired() must update _shared_token after refresh"""
+        token_manager.refresh_token_if_expired()
+
+        assert token_manager._shared_token == "refreshed_token"
+
+    def test_no_double_refresh_on_subsequent_get_access_token(self, token_manager, mocker):
+        """Regression: get_access_token() after refresh_token_if_expired() must not trigger a second refresh"""
+        token_manager.refresh_token_if_expired()
+
+        mock_refresh = mocker.patch.object(token_manager._credentials, "refresh")
+        token_manager.get_access_token()
+
+        mock_refresh.assert_not_called()
+
+    def test_clears_shared_token_on_refresh_failure(self, token_manager, mocker):
+        mocker.patch.object(
+            token_manager._credentials, "refresh", side_effect=Exception("network error")
+        )
+
+        token_manager._shared_token = "old_token"
+        token_manager.refresh_token_if_expired()
+
+        assert token_manager._shared_token is None
+
+
+class TestGetAccessToken:
+    def test_returns_cached_token_without_refresh(self, token_manager, mocker):
+        """Must return the cached token without calling credentials.refresh()"""
+        token_manager._shared_token = "cached_token"
+        token_manager._credentials._expired = False
+
+        mock_refresh = mocker.patch.object(token_manager._credentials, "refresh")
+        result = token_manager.get_access_token()
+
+        assert result == "cached_token"
+        mock_refresh.assert_not_called()
+
+    def test_refreshes_and_returns_token_when_none(self, token_manager):
+        """Must call credentials.refresh() and return the new token when _shared_token is None"""
+        assert token_manager._shared_token is None
+
+        result = token_manager.get_access_token()
+
+        assert result == "refreshed_token"
+        assert token_manager._shared_token == "refreshed_token"
+
+    def test_raises_invalid_data_error_on_refresh_failure(self, token_manager, mocker):
+        mocker.patch.object(
+            token_manager._credentials, "refresh", side_effect=Exception("auth failed")
+        )
+
+        with pytest.raises(InvalidDataError):
+            token_manager.get_access_token()
+
+    def test_thread_safe_single_refresh_under_concurrent_calls(self, token_manager):
+        """credentials.refresh() must be called only once even under concurrent calls from multiple threads"""
+        refresh_count = 0
+        original_refresh = token_manager._credentials.refresh
+
+        def counting_refresh(request):
+            nonlocal refresh_count
+            refresh_count += 1
+            original_refresh(request)
+
+        token_manager._credentials.refresh = counting_refresh
+
+        threads = [threading.Thread(target=token_manager.get_access_token) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert token_manager._shared_token == "refreshed_token"
+        assert refresh_count == 1


### PR DESCRIPTION
Fixes: #378 
Based: #377 

To prevent inconsistencies in access token management, we have made it so that tokens are shared between threads.
Separated out the processes responsible for token management into TokenManager.

## checks
- [x] All test has been passed.
- [x] linter, formatter reported no issues.