### PR TITLE
feat: Ensure service account file exists before initializing credentials

### DIFF
--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -8,6 +8,7 @@ from typing import Optional
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+from os import path
 
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
@@ -177,6 +178,13 @@ class BaseAPI(object):
         Initialize credentials and FCM endpoint if not already initialized.
         """
         if self.credentials is None:
+
+            missing_account_file = not path.isfile(self._service_account_file)
+
+            if missing_account_file:
+                raise InvalidDataError(f"The service account file you passed does not exist at '{path}'. "
+                                        "Ensure it does not have any typos and exists."
+                                        )
             self.credentials = service_account.Credentials.from_service_account_file(
                 self._service_account_file,
                 scopes=["https://www.googleapis.com/auth/firebase.messaging"],

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -9,7 +9,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 from os import path
-
+from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 import google.auth.transport.requests
 
@@ -181,7 +181,7 @@ class BaseAPI(object):
                 raise InvalidDataError(f"The service account file you passed does not exist at '{self._service_account_file}'. "
                                         "Ensure it does not have any typos and exists."
                                         )
-            self.credentials = Credentials.from_service_account_file(
+            self.credentials = service_account.Credentials.from_service_account_file(
                 self._service_account_file,
                 scopes=["https://www.googleapis.com/auth/firebase.messaging"],
             )

--- a/pyfcm/baseapi.py
+++ b/pyfcm/baseapi.py
@@ -10,7 +10,6 @@ from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 from os import path
 
-from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 import google.auth.transport.requests
 
@@ -178,14 +177,11 @@ class BaseAPI(object):
         Initialize credentials and FCM endpoint if not already initialized.
         """
         if self.credentials is None:
-
-            missing_account_file = not path.isfile(self._service_account_file)
-
-            if missing_account_file:
-                raise InvalidDataError(f"The service account file you passed does not exist at '{path}'. "
+            if not path.isfile(self._service_account_file):
+                raise InvalidDataError(f"The service account file you passed does not exist at '{self._service_account_file}'. "
                                         "Ensure it does not have any typos and exists."
                                         )
-            self.credentials = service_account.Credentials.from_service_account_file(
+            self.credentials = Credentials.from_service_account_file(
                 self._service_account_file,
                 scopes=["https://www.googleapis.com/auth/firebase.messaging"],
             )

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -10,7 +10,6 @@ def test_push_service_without_credentials():
 
 def test_push_service_with_incorrect_service_account_file():
     try:
-        # figure out why this goddamn test is not running
         fcm = FCMNotification(service_account_file='./foo.json', project_id=None, credentials=None)
         fcm.notify()
         assert False, "Should raise InvalidDataError without correct service account file path"

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -8,6 +8,14 @@ def test_push_service_without_credentials():
     except errors.AuthenticationError:
         pass
 
+def test_push_service_with_incorrect_service_account_file():
+    try:
+        # figure out why this goddamn test is not running
+        fcm = FCMNotification(service_account_file='./foo.json', project_id=None, credentials=None)
+        fcm.notify()
+        assert False, "Should raise InvalidDataError without correct service account file path"
+    except errors.InvalidDataError:
+        pass
 
 def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials

--- a/tests/test_fcm.py
+++ b/tests/test_fcm.py
@@ -16,6 +16,26 @@ def test_push_service_with_incorrect_service_account_file():
     except errors.InvalidDataError:
         pass
 
+def test_push_service_with_valid_service_account_file(mocker):
+    # When the service account file exists, credentials must be built via
+    # google.oauth2.service_account.Credentials.from_service_account_file.
+    # google.oauth2.credentials.Credentials does not provide that method.
+    mocker.patch("pyfcm.baseapi.path.isfile", return_value=True)
+    mock_from_file = mocker.patch(
+        "pyfcm.baseapi.service_account.Credentials.from_service_account_file",
+        return_value="dummy-credentials",
+    )
+
+    fcm = FCMNotification(
+        service_account_file="./service_account.json",
+        project_id="test",
+        credentials=None,
+    )
+    fcm._initialize_credentials()
+
+    mock_from_file.assert_called_once()
+    assert fcm.credentials == "dummy-credentials"
+
 def test_push_service_directly_passed_credentials(push_service):
     # We should infer the project ID/endpoint from credentials
     # without the need to explcitily pass it


### PR DESCRIPTION
This PR adds a validation check to ensure that the service_account_file path passed to FCM exists before attempting to initialize credentials using Google OAuth.

References #385.